### PR TITLE
fix: calculate last lba of partition correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-08T22:09:46Z by kres latest.
+# Generated on 2020-10-06T16:24:33Z by kres latest.
 
 # common variables
 
@@ -8,13 +8,13 @@ SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
-REGISTRY ?= docker.io
-USERNAME ?= autonomy
+REGISTRY ?= ghcr.io
+USERNAME ?= talos-systems
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.14
 TESTPKGS ?= ./...
-KRES_IMAGE ?= autonomy/kres:latest
+KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
 
 # docker build settings
 

--- a/blockdevice/table/gpt/gpt.go
+++ b/blockdevice/table/gpt/gpt.go
@@ -289,7 +289,8 @@ func (gpt *GPT) Add(size uint64, setters ...interface{}) (table.Partition, error
 			return nil, fmt.Errorf("requested partition with maximum size, but no space available")
 		}
 	} else {
-		end = start + size/gpt.lba.LogicalBlockSize
+		// in GPT, partition end is inclusive
+		end = start + size/gpt.lba.LogicalBlockSize - 1
 
 		if end > gpt.header.LastUsableLBA {
 			// Convert the total available LBAs to units of bytes.

--- a/blockdevice/table/gpt/gpt_test.go
+++ b/blockdevice/table/gpt/gpt_test.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package gpt_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	bdtable "github.com/talos-systems/go-blockdevice/blockdevice/table"
+	"github.com/talos-systems/go-blockdevice/blockdevice/table/gpt"
+	"github.com/talos-systems/go-blockdevice/blockdevice/table/gpt/partition"
+)
+
+const (
+	size      = 1024 * 1024 * 1024 * 1024
+	blockSize = 512
+
+	headReserved = 33
+	tailReserved = 34
+)
+
+type GPTSuite struct {
+	suite.Suite
+
+	f *os.File
+}
+
+func (suite *GPTSuite) SetupTest() {
+	var err error
+
+	suite.f, err = ioutil.TempFile("", "blockdevice")
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.f.Truncate(size))
+}
+
+func (suite *GPTSuite) TearDownTest() {
+	suite.Assert().NoError(suite.f.Close())
+	suite.Assert().NoError(os.Remove(suite.f.Name()))
+}
+
+func (suite *GPTSuite) TestPartitionAdd() {
+	table, err := gpt.NewGPT("/dev/null", suite.f)
+	suite.Require().NoError(err)
+
+	_, err = table.New()
+	suite.Require().NoError(err)
+
+	const (
+		bootSize = 1048576
+		efiSize  = 512 * 1048576
+	)
+
+	_, err = table.Add(bootSize, partition.WithPartitionName("boot"))
+	suite.Require().NoError(err)
+
+	_, err = table.Add(efiSize, partition.WithPartitionName("efi"))
+	suite.Require().NoError(err)
+
+	_, err = table.Add(0, partition.WithPartitionName("system"), partition.WithMaximumSize(true))
+	suite.Require().NoError(err)
+
+	assertPartitions := func(partitions []bdtable.Partition) {
+		suite.Require().Len(partitions, 3)
+
+		partBoot := partitions[0]
+		suite.Assert().EqualValues(1, partBoot.No())
+		suite.Assert().EqualValues(bootSize/blockSize, partBoot.Length())
+		suite.Assert().EqualValues(headReserved+1, partBoot.Start()) // first usable LBA
+
+		partEFI := partitions[1]
+		suite.Assert().EqualValues(2, partEFI.No())
+		suite.Assert().EqualValues(efiSize/blockSize, partEFI.Length())
+		suite.Assert().EqualValues(headReserved+1+bootSize/blockSize, partEFI.Start())
+
+		partSystem := partitions[2]
+		suite.Assert().EqualValues(3, partSystem.No())
+		suite.Assert().EqualValues((size-bootSize-efiSize)/blockSize-headReserved-tailReserved, partSystem.Length())
+		suite.Assert().EqualValues(headReserved+1+bootSize/blockSize+efiSize/blockSize, partSystem.Start())
+	}
+
+	assertPartitions(table.Partitions())
+
+	suite.Require().NoError(table.Write())
+
+	// re-read the partition table
+	table, err = gpt.NewGPT("/dev/null", suite.f)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(table.Read())
+
+	assertPartitions(table.Partitions())
+}
+
+func TestGPTSuite(t *testing.T) {
+	suite.Run(t, new(GPTSuite))
+}

--- a/blockdevice/table/gpt/partition/partition.go
+++ b/blockdevice/table/gpt/partition/partition.go
@@ -50,9 +50,7 @@ func (prt *Partition) Start() int64 {
 
 // Length returns the partition's length in LBA.
 func (prt *Partition) Length() int64 {
-	// TODO(andrewrynhard): For reasons I don't understand right now, we need
-	// to add 1 in order to align with what partx thinks is the length of the
-	// partition.
+	// in GPT, LastLBA is inclusive, so +1
 	return int64(prt.LastLBA - prt.FirstLBA + 1)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/google/uuid v1.1.2
+	github.com/stretchr/testify v1.6.1
 	github.com/talos-systems/go-retry v0.1.0
 	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a
 	golang.org/x/text v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/talos-systems/go-retry v0.1.0 h1:O+OeZR54CQ1+ch99p/81Pqi5GqJH6LIu1MTN/N0vd78=
 github.com/talos-systems/go-retry v0.1.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a h1:i47hUS795cOydZI4AwJQCKXOr4BvxzvikwDoDtHhP2Y=
@@ -7,3 +14,7 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This fixes off-by-one block error in partition size being created.

If requested to create partition of N blocks, library created partition
of N+1 blocks.

Also adds first unit-tests for the GPT (more coming).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>