### PR TITLE
feat: expose partition name (label)

### DIFF
--- a/blockdevice/table/gpt/gpt_test.go
+++ b/blockdevice/table/gpt/gpt_test.go
@@ -71,16 +71,19 @@ func (suite *GPTSuite) TestPartitionAdd() {
 
 		partBoot := partitions[0]
 		suite.Assert().EqualValues(1, partBoot.No())
+		suite.Assert().EqualValues("boot", partBoot.Label())
 		suite.Assert().EqualValues(bootSize/blockSize, partBoot.Length())
 		suite.Assert().EqualValues(headReserved+1, partBoot.Start()) // first usable LBA
 
 		partEFI := partitions[1]
 		suite.Assert().EqualValues(2, partEFI.No())
+		suite.Assert().EqualValues("efi", partEFI.Label())
 		suite.Assert().EqualValues(efiSize/blockSize, partEFI.Length())
 		suite.Assert().EqualValues(headReserved+1+bootSize/blockSize, partEFI.Start())
 
 		partSystem := partitions[2]
 		suite.Assert().EqualValues(3, partSystem.No())
+		suite.Assert().EqualValues("system", partSystem.Label())
 		suite.Assert().EqualValues((size-bootSize-efiSize)/blockSize-headReserved-tailReserved, partSystem.Length())
 		suite.Assert().EqualValues(headReserved+1+bootSize/blockSize+efiSize/blockSize, partSystem.Start())
 	}

--- a/blockdevice/table/gpt/partition/partition.go
+++ b/blockdevice/table/gpt/partition/partition.go
@@ -59,6 +59,11 @@ func (prt *Partition) No() int32 {
 	return prt.Number
 }
 
+// Label returns the partition's name.
+func (prt *Partition) Label() string {
+	return prt.Name
+}
+
 // Fields implements the serder.Serde interface.
 func (prt *Partition) Fields() []*serde.Field {
 	return []*serde.Field{

--- a/blockdevice/table/table.go
+++ b/blockdevice/table/table.go
@@ -58,6 +58,8 @@ type Partition interface {
 	Length() int64
 	// No returns the partition's number.
 	No() int32
+	// Label returns the partitions' name.
+	Label() string
 	serde.Serde
 }
 


### PR DESCRIPTION
I had to use name `Label()` as `Name` is already used for the struct
field.

This would allow us to match existing partitions to the new manifest, so
that we can preserve contents of the partition before wiping.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>