### PR TITLE
refactor: expose `InsertAt` method via interface

### DIFF
--- a/blockdevice/table/gpt/gpt.go
+++ b/blockdevice/table/gpt/gpt.go
@@ -303,7 +303,7 @@ func (gpt *GPT) Add(size uint64, setters ...interface{}) (table.Partition, error
 	return gpt.InsertAt(len(gpt.partitions), size, setters...)
 }
 
-// InsertAt inserts partition after the partition at the position idx.
+// InsertAt inserts partition before the partition at the position idx.
 //
 // If idx == 0, it inserts new partition as the first partition, etc., idx == 1 as the second, etc.
 func (gpt *GPT) InsertAt(idx int, size uint64, setters ...interface{}) (table.Partition, error) {

--- a/blockdevice/table/table.go
+++ b/blockdevice/table/table.go
@@ -4,7 +4,9 @@
 
 package table
 
-import "github.com/talos-systems/go-blockdevice/blockdevice/serde"
+import (
+	"github.com/talos-systems/go-blockdevice/blockdevice/serde"
+)
 
 // Table represents a partition table.
 type Table = []byte
@@ -67,6 +69,8 @@ type Partition interface {
 type Partitioner interface {
 	// Add adds a partition to the partition table.
 	Add(uint64, ...interface{}) (Partition, error)
+	// InsertAt inserts partition before the partition at the position idx.
+	InsertAt(idx int, size uint64, setters ...interface{}) (Partition, error)
 	// Resize resizes a partition table.
 	Resize(Partition) error
 	// Delete deletes a partition table.


### PR DESCRIPTION
External code is using generic interface, not GPT code directly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>