### PR TITLE
fix: sync kernel partition table incrementally

### DIFF
--- a/blockdevice/blkpg/blkpg.go
+++ b/blockdevice/blkpg/blkpg.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package blkpg
+
+// KernelPartition represents kernel partition info.
+type KernelPartition struct {
+	No     int
+	Start  int64
+	Length int64
+}

--- a/blockdevice/blkpg/blkpg_darwin.go
+++ b/blockdevice/blkpg/blkpg_darwin.go
@@ -25,3 +25,8 @@ func InformKernelOfResize(f *os.File, partition table.Partition) error {
 func InformKernelOfDelete(f *os.File, partition table.Partition) error {
 	return fmt.Errorf("not implemented")
 }
+
+// GetKernelPartitions returns kernel state of partitions.
+func GetKernelPartitions(f *os.File, devPath string) ([]KernelPartition, error) {
+	return nil, fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
Previous strategy was to drop every kernel partition and replace it with
the new partitions, but this fails when Talos tries to resize ephemeral
partition on boot: other partitions are already mounted, so they can't
be removed from the kernel state.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>