### PR TITLE
feat: add support for changing partition entries start LBA

### DIFF
--- a/blockdevice/table/gpt/gpt_test.go
+++ b/blockdevice/table/gpt/gpt_test.go
@@ -22,7 +22,7 @@ const (
 	size      = 1024 * 1024 * 1024 * 1024
 	blockSize = 512
 
-	headReserved = 33
+	headReserved = 2079
 	tailReserved = 34
 )
 
@@ -131,7 +131,7 @@ func (suite *GPTSuite) TestPartitionAddOutOfSpace() {
 
 	_, err = table.Add(size, partition.WithPartitionName("boot"))
 	suite.Require().Error(err)
-	suite.Assert().EqualError(err, `requested partition size 1099511627776, available is 1099511592960 (34816 too many bytes)`)
+	suite.Assert().EqualError(err, `requested partition size 1099511627776, available is 1099510545408 (1082368 too many bytes)`)
 	suite.Assert().True(blockdevice.IsOutOfSpaceError(err))
 
 	_, err = table.Add(size/2, partition.WithPartitionName("boot"))
@@ -139,7 +139,7 @@ func (suite *GPTSuite) TestPartitionAddOutOfSpace() {
 
 	_, err = table.Add(size/2, partition.WithPartitionName("boot2"))
 	suite.Require().Error(err)
-	suite.Assert().EqualError(err, `requested partition size 549755813888, available is 549755779072 (34816 too many bytes)`)
+	suite.Assert().EqualError(err, `requested partition size 549755813888, available is 549754731520 (1082368 too many bytes)`)
 	suite.Assert().True(blockdevice.IsOutOfSpaceError(err))
 
 	_, err = table.Add(size/2-(headReserved+tailReserved)*blockSize, partition.WithPartitionName("boot2"))

--- a/blockdevice/table/gpt/header/header.go
+++ b/blockdevice/table/gpt/header/header.go
@@ -281,7 +281,7 @@ func (hdr *Header) Fields() []*serde.Field {
 					return fmt.Errorf("option is not a GPT header option")
 				}
 				hdr.PartitionEntriesStartLBA = binary.LittleEndian.Uint64(contents)
-				array, err := hdr.From(o.Table, lba.Range{Start: hdr.PartitionEntriesStartLBA, End: uint64(33)})
+				array, err := hdr.From(o.Table, lba.Range{Start: hdr.PartitionEntriesStartLBA, End: hdr.PartitionEntriesStartLBA + 31})
 				if err != nil {
 					return fmt.Errorf("failed to read starting LBA from header: %w", err)
 				}

--- a/blockdevice/table/gpt/options.go
+++ b/blockdevice/table/gpt/options.go
@@ -6,7 +6,8 @@ package gpt
 
 // Options is the functional options struct.
 type Options struct {
-	PrimaryGPT bool
+	PrimaryGPT               bool
+	PartitionEntriesStartLBA uint64
 }
 
 // Option is the functional option func.
@@ -19,10 +20,18 @@ func WithPrimaryGPT(o bool) Option {
 	}
 }
 
+// WithPartitionEntriesStartLBA  sets the LBA to be used for specifying which LBA should be used for the start of the partition entries.
+func WithPartitionEntriesStartLBA(o uint64) Option {
+	return func(args *Options) {
+		args.PartitionEntriesStartLBA = o
+	}
+}
+
 // NewDefaultOptions initializes a Options struct with default values.
 func NewDefaultOptions(setters ...interface{}) *Options {
 	opts := &Options{
-		PrimaryGPT: true,
+		PrimaryGPT:               true,
+		PartitionEntriesStartLBA: 2048,
 	}
 
 	for _, setter := range setters {

--- a/blockdevice/util/util_test.go
+++ b/blockdevice/util/util_test.go
@@ -217,3 +217,47 @@ func Test_DevnameFromPartname(t *testing.T) {
 		})
 	}
 }
+
+func TestPartName(t *testing.T) {
+	type args struct {
+		d string
+		n int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "loop",
+			args: args{
+				d: "loop0",
+				n: 5,
+			},
+			want: "loop0p5",
+		},
+		{
+			name: "mmc",
+			args: args{
+				d: "mmcblk0",
+				n: 9,
+			},
+			want: "mmcblk0p9",
+		},
+		{
+			name: "nvme1n2",
+			args: args{
+				d: "nvme1n2",
+				n: 1,
+			},
+			want: "nvme1n2p1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := util.PartName(tt.args.d, tt.args.n); got != tt.want {
+				t.Errorf("PartName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds an option for changing the partition entries start LBA. This is required to do things like
use GPT with u-boot.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
