### PR TITLE
fix: correctly build paths for `mmcblk` devices

### DIFF
--- a/blockdevice/util/util.go
+++ b/blockdevice/util/util.go
@@ -18,6 +18,8 @@ func PartNo(partname string) (partno string, err error) {
 	switch p := partname; {
 	case strings.HasPrefix(p, "nvme"):
 		fallthrough
+	case strings.HasPrefix(p, "mmcblk"):
+		fallthrough
 	case strings.HasPrefix(p, "loop"):
 		idx := strings.LastIndex(partname, "p")
 
@@ -48,6 +50,8 @@ func DevnameFromPartname(partname string) (devname string, err error) {
 	switch p := partname; {
 	case strings.HasPrefix(p, "nvme"):
 		fallthrough
+	case strings.HasPrefix(p, "mmcblk"):
+		fallthrough
 	case strings.HasPrefix(p, "loop"):
 		return strings.TrimSuffix(p, "p"+partno), nil
 	case strings.HasPrefix(p, "sd"):
@@ -69,6 +73,8 @@ func PartName(d string, n int) string {
 
 	switch p := partname; {
 	case strings.HasPrefix(p, "nvme"):
+		fallthrough
+	case strings.HasPrefix(p, "mmcblk"):
 		fallthrough
 	case strings.HasPrefix(p, "loop"):
 		partname = fmt.Sprintf("%sp%d", p, n)

--- a/blockdevice/util/util_test.go
+++ b/blockdevice/util/util_test.go
@@ -112,6 +112,13 @@ func Test_PartNo(t *testing.T) {
 			},
 			want: "4",
 		},
+		{
+			name: "mmcblk0p3",
+			args: args{
+				devname: "mmcblk0p3",
+			},
+			want: "3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -190,6 +197,14 @@ func Test_DevnameFromPartname(t *testing.T) {
 				partno:  "4",
 			},
 			want: "loop4",
+		},
+		{
+			name: "mmcblk0p3",
+			args: args{
+				devname: "mmcblk0p3",
+				partno:  "3",
+			},
+			want: "mmcblk0",
 		},
 	}
 


### PR DESCRIPTION
Ex: `mmcblk0p1`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>