### PR TITLE
feat: allow for custom partition entries start LBA

### DIFF
--- a/blockdevice/table/gpt/header/header.go
+++ b/blockdevice/table/gpt/header/header.go
@@ -281,7 +281,7 @@ func (hdr *Header) Fields() []*serde.Field {
 					return fmt.Errorf("option is not a GPT header option")
 				}
 				hdr.PartitionEntriesStartLBA = binary.LittleEndian.Uint64(contents)
-				array, err := hdr.From(o.Table, lba.Range{Start: hdr.PartitionEntriesStartLBA, End: uint64(33)})
+				array, err := hdr.From(o.Table, lba.Range{Start: hdr.PartitionEntriesStartLBA, End: hdr.PartitionEntriesStartLBA + 31})
 				if err != nil {
 					return fmt.Errorf("failed to read starting LBA from header: %w", err)
 				}

--- a/blockdevice/table/table.go
+++ b/blockdevice/table/table.go
@@ -28,7 +28,7 @@ type PartitionTable interface {
 	// Repair repairs a partition table.
 	Repair() error
 	// New creates a new partition table.
-	New() (PartitionTable, error)
+	New(...interface{}) (PartitionTable, error)
 	// Partitioner must be implemented by a partition table.
 	Partitioner
 }


### PR DESCRIPTION
It can be useful to customize where partition enties start. This allows for
setting a custom LBA on which to start partitions.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
