### PR TITLE
fix: ignore `/dev/ram` devices

### DIFF
--- a/blockdevice/util/disks.go
+++ b/blockdevice/util/disks.go
@@ -58,7 +58,7 @@ func GetDisks() ([]*Disk, error) {
 		skip := false
 		deviceName := filepath.Base(dev.Name())
 
-		for _, prefix := range []string{"sg", "sr", "loop", "md", "dm-"} {
+		for _, prefix := range []string{"sg", "sr", "loop", "md", "dm-", "ram"} {
 			if strings.HasPrefix(deviceName, prefix) {
 				skip = true
 


### PR DESCRIPTION
These are not what we can install onto, they appear on RPi4.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>