### PR TITLE
fix: blockdevice reset should read partition table from disk

### DIFF
--- a/blockdevice/blockdevice_linux.go
+++ b/blockdevice/blockdevice_linux.go
@@ -250,12 +250,17 @@ func (bd *BlockDevice) WipeRange(start, length uint64) (string, error) {
 
 // Reset will reset a block device given a device name.
 // Simply deletes partition table on device.
-func (bd *BlockDevice) Reset() (err error) {
-	for _, p := range bd.g.Partitions().Items() {
-		if err = bd.g.Delete(p); err != nil {
+func (bd *BlockDevice) Reset() error {
+	g, err := bd.PartitionTable()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range g.Partitions().Items() {
+		if err = g.Delete(p); err != nil {
 			return fmt.Errorf("failed to delete partition: %w", err)
 		}
 	}
 
-	return bd.g.Write()
+	return g.Write()
 }

--- a/blockdevice/lba/lba_linux.go
+++ b/blockdevice/lba/lba_linux.go
@@ -70,6 +70,8 @@ func (l *LBA) ReadAt(lba, off, length int64) (b []byte, err error) {
 
 	off = lba*l.LogicalBlockSize + off
 
+	// TODO: this should either use a loop or ReadFull, as Read() is not guaranteed
+	// to read full buffer
 	n, err := l.f.ReadAt(b, off)
 	if err != nil {
 		return nil, err

--- a/blockdevice/partition/gpt/header.go
+++ b/blockdevice/partition/gpt/header.go
@@ -334,6 +334,10 @@ func (h *Header) DeserializeSize() (err error) {
 
 	h.Size = binary.LittleEndian.Uint32(data)
 
+	if h.Size < HeaderSize {
+		return fmt.Errorf("header size too small: %d", h.Size)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The problem was that partition table was never read from disk, so header
was written uninitialized (with zeroes). That leads to `header.Size`
being zero which in turns leads to panic in `DeserializeCRC` which
doesn't do any bounds checking before accessing the slice.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>