### PR TITLE
feat: add an option to open block device with exclusive flock

### DIFF
--- a/blockdevice/blockdevice_linux.go
+++ b/blockdevice/blockdevice_linux.go
@@ -63,6 +63,14 @@ func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {
 		}
 	}()
 
+	if opts.ExclusiveLock {
+		if err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+			err = fmt.Errorf("error locking device %q: %w", devname, err)
+
+			return nil, err
+		}
+	}
+
 	if opts.CreateGPT {
 		var g *gpt.GPT
 

--- a/blockdevice/options.go
+++ b/blockdevice/options.go
@@ -6,7 +6,8 @@ package blockdevice
 
 // Options is the functional options struct.
 type Options struct {
-	CreateGPT bool
+	CreateGPT     bool
+	ExclusiveLock bool
 }
 
 // Option is the functional option func.
@@ -16,6 +17,13 @@ type Option func(*Options)
 func WithNewGPT(o bool) Option {
 	return func(args *Options) {
 		args.CreateGPT = o
+	}
+}
+
+// WithExclusiveLock locks the blockdevice for exclusive access using flock().
+func WithExclusiveLock(o bool) Option {
+	return func(args *Options) {
+		args.ExclusiveLock = o
 	}
 }
 


### PR DESCRIPTION
The problem is the interaction of udevd and our code managing partition
table: udevd might trigger `BLKRRPART` ioctl concurrently with our code
which tries to sync partition table which leads to a mess.

With `flock(LOCK_EX)` udevd skips `BLKRRPART` syscall.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>