### PR TITLE
fix: properly handle no child processes error from cmd.Wait

### DIFF
--- a/blockdevice/encryption/luks/luks.go
+++ b/blockdevice/encryption/luks/luks.go
@@ -251,7 +251,9 @@ func (l *LUKS) runCommand(args []string, stdin []byte) error {
 			}
 		}
 
-		return fmt.Errorf("failed to call cryptsetup: %w, output: %s", err, out.String())
+		if !strings.Contains(err.Error(), "no child processes") {
+			return fmt.Errorf("failed to call cryptsetup: %w, output: %s", err, out.String())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I guess that happens when the process ends before `Wait` kicks in.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>