### PR TITLE
fix: align partition start to physical sector size

### DIFF
--- a/blockdevice/lba/lba.go
+++ b/blockdevice/lba/lba.go
@@ -57,3 +57,14 @@ type LBA struct {
 
 	f *os.File
 }
+
+// AlignToPhysicalBlockSize aligns LBA value in LogicalBlockSize multiples to be aligned to PhysicalBlockSize.
+func (l *LBA) AlignToPhysicalBlockSize(lba uint64) uint64 {
+	physToLogical := uint64(l.PhysicalBlockSize / l.LogicalBlockSize)
+
+	if physToLogical <= 1 {
+		return lba
+	}
+
+	return (lba + physToLogical - 1) / physToLogical * physToLogical
+}

--- a/blockdevice/lba/lba_test.go
+++ b/blockdevice/lba/lba_test.go
@@ -4,11 +4,25 @@
 
 package lba_test
 
-import "testing"
+import (
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/go-blockdevice/blockdevice/lba"
+)
+
+func TestAlignToPhysicalBlockSize(t *testing.T) {
+	l := lba.LBA{ //nolint: exhaustivestruct
+		PhysicalBlockSize: 4096,
+		LogicalBlockSize:  512,
+	}
+
+	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0))
+	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(1))
+	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(2))
+	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(3))
+	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(4))
+	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(8))
+	assert.EqualValues(t, 16, l.AlignToPhysicalBlockSize(9))
 }

--- a/blockdevice/partition/gpt/gpt.go
+++ b/blockdevice/partition/gpt/gpt.go
@@ -245,7 +245,7 @@ func (g *GPT) InsertAt(idx int, size uint64, setters ...PartitionOption) (*Parti
 	// Find partition boundaries.
 	var start, end uint64
 
-	start = minLBA
+	start = g.l.AlignToPhysicalBlockSize(minLBA)
 
 	if opts.MaximumSize {
 		end = maxLBA


### PR DESCRIPTION
Misaligning partition start leads to sub-optimal I/O performance.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>