### PR TITLE
fix: Mark the EFI partition in PMBR as bootable.

### DIFF
--- a/blockdevice/partition/gpt/gpt.go
+++ b/blockdevice/partition/gpt/gpt.go
@@ -344,6 +344,7 @@ func (g *GPT) Repair() error {
 // 	- https://en.wikipedia.org/wiki/GUID_Partition_Table#Protective_MBR_(LBA_0)
 // 	- https://www.syslinux.org/wiki/index.php?title=Doc/gpt
 // 	- https://en.wikipedia.org/wiki/Master_boot_record
+//      - http://www.rodsbooks.com/gdisk/bios.html
 func (g *GPT) newPMBR(h *Header) ([]byte, error) {
 	p, err := g.l.ReadAt(0, 0, 512)
 	if err != nil {
@@ -355,7 +356,10 @@ func (g *GPT) newPMBR(h *Header) ([]byte, error) {
 
 	// PMBR protective entry.
 	b := p[446 : 446+16]
-	b[0] = 0x00
+
+	// Some BIOSes in legacy mode won't boot from a disk unless there is at least one
+	// partition in the MBR marked bootable.  Mark this partition as bootable.
+	b[0] = 0x80
 
 	// Partition type: EFI data partition.
 	b[4] = 0xee


### PR DESCRIPTION
Some legacy BIOSes need to see at least one bootable partition in the MBR to attempt to boot from the disk.