### PR TITLE
fix: revert mark the EFI partition in PMBR as bootable

### DIFF
--- a/blockdevice/partition/gpt/gpt.go
+++ b/blockdevice/partition/gpt/gpt.go
@@ -344,7 +344,6 @@ func (g *GPT) Repair() error {
 // 	- https://en.wikipedia.org/wiki/GUID_Partition_Table#Protective_MBR_(LBA_0)
 // 	- https://www.syslinux.org/wiki/index.php?title=Doc/gpt
 // 	- https://en.wikipedia.org/wiki/Master_boot_record
-//      - http://www.rodsbooks.com/gdisk/bios.html
 func (g *GPT) newPMBR(h *Header) ([]byte, error) {
 	p, err := g.l.ReadAt(0, 0, 512)
 	if err != nil {
@@ -356,10 +355,7 @@ func (g *GPT) newPMBR(h *Header) ([]byte, error) {
 
 	// PMBR protective entry.
 	b := p[446 : 446+16]
-
-	// Some BIOSes in legacy mode won't boot from a disk unless there is at least one
-	// partition in the MBR marked bootable.  Mark this partition as bootable.
-	b[0] = 0x80
+	b[0] = 0x00
 
 	// Partition type: EFI data partition.
 	b[4] = 0xee


### PR DESCRIPTION
This reverts commit bec914ffdda42abcfe642bc2cdfc9fcda56a74ee.

This breaks UEFI boot.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>