### PR TITLE
fix: make disk type matcher parser case insensitive

### DIFF
--- a/blockdevice/util/disk/disks.go
+++ b/blockdevice/util/disk/disks.go
@@ -50,6 +50,8 @@ func (t Type) String() string {
 
 // ParseType converts string id to the disk type id.
 func ParseType(id string) (Type, error) {
+	id = strings.ToLower(id)
+
 	switch id {
 	case "ssd":
 		return TypeSSD, nil


### PR DESCRIPTION
We show disk type as uppercase in `talosctl disk`, so it may happen that
someone will specify it in uppercase in the matcher as well.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>