### PR TITLE
feat: expose more encryption options in the LUKS module

### DIFF
--- a/blockdevice/encryption/luks/luks_test.go
+++ b/blockdevice/encryption/luks/luks_test.go
@@ -59,6 +59,7 @@ func (suite *LUKSSuite) TestEncrypt() {
 	provider := luks.New(
 		luks.AESXTSPlain64Cipher,
 		luks.WithIterTime(time.Millisecond*100),
+		luks.WithPerfOptions(luks.PerfSameCPUCrypt),
 	)
 
 	_, err = g.Add(bootSize, gpt.WithPartitionName("boot"))
@@ -153,9 +154,7 @@ func TestLUKSSuite(t *testing.T) {
 		t.Skip("can't run the test as non-root")
 	}
 
-	hostname, _ := os.Hostname() //nolint: errcheck
-
-	if hostname == "buildkitsandbox" {
+	if hostname, _ := os.Hostname(); hostname == "buildkitsandbox" { //nolint:errcheck
 		t.Skip("test not supported under buildkit as partition devices are not propagated from /dev")
 	}
 

--- a/blockdevice/encryption/luks/options.go
+++ b/blockdevice/encryption/luks/options.go
@@ -30,3 +30,24 @@ func WithPBKDFMemory(value uint64) Option {
 		l.pbkdfMemory = value
 	}
 }
+
+// WithKeySize sets generated key size.
+func WithKeySize(value uint) Option {
+	return func(l *LUKS) {
+		l.keySize = value
+	}
+}
+
+// WithBlockSize sets block size.
+func WithBlockSize(value uint64) Option {
+	return func(l *LUKS) {
+		l.blockSize = value
+	}
+}
+
+// WithPerfOptions enables encryption perf options.
+func WithPerfOptions(options ...string) Option {
+	return func(l *LUKS) {
+		l.perfOptions = options
+	}
+}


### PR DESCRIPTION
Add `xchacha12,aes-adiantum-plain64` and `xchacha20,aes-adiantum-plain64` ciphers.
Expose handles for tweaking `--sector-size` and `--key-size`.
Provide a way to set some of the `--perf` flags.

cc: @sergelogvinov Please let me know if I read the issue you created correctly.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>