### PR TITLE
feat: align partition to minimum I/O size

### DIFF
--- a/blockdevice/lba/lba.go
+++ b/blockdevice/lba/lba.go
@@ -53,7 +53,10 @@ func (buf *Buffer) Bytes() []byte {
 type LBA struct {
 	PhysicalBlockSize int64
 	LogicalBlockSize  int64
-	TotalSectors      int64
+	MinimalIOSize     int64
+	OptimalIOSize     int64
+
+	TotalSectors int64
 
 	f *os.File
 }
@@ -61,10 +64,16 @@ type LBA struct {
 // AlignToPhysicalBlockSize aligns LBA value in LogicalBlockSize multiples to be aligned to PhysicalBlockSize.
 func (l *LBA) AlignToPhysicalBlockSize(lba uint64) uint64 {
 	physToLogical := uint64(l.PhysicalBlockSize / l.LogicalBlockSize)
+	minIOToLogical := uint64(l.MinimalIOSize / l.LogicalBlockSize)
 
-	if physToLogical <= 1 {
+	ratio := physToLogical
+	if minIOToLogical > ratio {
+		ratio = minIOToLogical
+	}
+
+	if ratio <= 1 {
 		return lba
 	}
 
-	return (lba + physToLogical - 1) / physToLogical * physToLogical
+	return (lba + ratio - 1) / ratio * ratio
 }

--- a/blockdevice/lba/lba_test.go
+++ b/blockdevice/lba/lba_test.go
@@ -26,3 +26,20 @@ func TestAlignToPhysicalBlockSize(t *testing.T) {
 	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(8))
 	assert.EqualValues(t, 16, l.AlignToPhysicalBlockSize(9))
 }
+
+func TestAlignToMinIOkSize(t *testing.T) {
+	l := lba.LBA{ //nolint: exhaustivestruct
+		MinimalIOSize:     262144,
+		PhysicalBlockSize: 512,
+		LogicalBlockSize:  512,
+	}
+
+	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(1))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(2))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(3))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(4))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(8))
+	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(512))
+	assert.EqualValues(t, 1024, l.AlignToPhysicalBlockSize(513))
+}


### PR DESCRIPTION
Gather information about minimum/optimal I/O size for the disks and
align partitions to either physical block size or min i/o size,
whichever is bigger.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>