### PR TITLE
feat: make probe always open blockdevices in readonly mode

### DIFF
--- a/blockdevice/blockdevice_darwin.go
+++ b/blockdevice/blockdevice_darwin.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
 )
 
@@ -17,6 +19,13 @@ type BlockDevice struct {
 
 	f *os.File
 }
+
+const (
+	// ReadonlyMode readonly mode.
+	ReadonlyMode = unix.O_CLOEXEC | os.O_RDONLY
+	// DefaultMode read write.
+	DefaultMode = unix.O_CLOEXEC | os.O_RDWR
+)
 
 // Open initializes and returns a block device.
 // TODO(andrewrynhard): Use BLKGETSIZE ioctl to get the size.

--- a/blockdevice/blockdevice_linux.go
+++ b/blockdevice/blockdevice_linux.go
@@ -29,9 +29,13 @@ const (
 	BLKZEROOUT       = 4735
 )
 
-// Fast wipe parameters.
 const (
+	// FastWipeRange fast wipe block.
 	FastWipeRange = 1024 * 1024
+	// ReadonlyMode readonly mode.
+	ReadonlyMode = unix.O_CLOEXEC | os.O_RDONLY
+	// DefaultMode read write.
+	DefaultMode = unix.O_CLOEXEC | os.O_RDWR
 )
 
 // BlockDevice represents a block device.
@@ -49,7 +53,7 @@ func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {
 
 	var f *os.File
 
-	if f, err = os.OpenFile(devname, os.O_RDWR|unix.O_CLOEXEC, os.ModeDevice); err != nil {
+	if f, err = os.OpenFile(devname, opts.Mode, os.ModeDevice); err != nil {
 		return nil, err
 	}
 

--- a/blockdevice/blockdevice_windows.go
+++ b/blockdevice/blockdevice_windows.go
@@ -18,6 +18,13 @@ type BlockDevice struct {
 	f *os.File
 }
 
+const (
+	// ReadonlyMode readonly mode.
+	ReadonlyMode = os.O_RDONLY
+	// DefaultMode read write.
+	DefaultMode = os.O_RDWR
+)
+
 // Open initializes and returns a block device.
 // TODO(andrewrynhard): Use BLKGETSIZE ioctl to get the size.
 func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {

--- a/blockdevice/options.go
+++ b/blockdevice/options.go
@@ -8,6 +8,7 @@ package blockdevice
 type Options struct {
 	CreateGPT     bool
 	ExclusiveLock bool
+	Mode          int
 }
 
 // Option is the functional option func.
@@ -27,10 +28,18 @@ func WithExclusiveLock(o bool) Option {
 	}
 }
 
+// WithMode opens blockdevice in a specific mode.
+func WithMode(value int) Option {
+	return func(args *Options) {
+		args.Mode = value
+	}
+}
+
 // NewDefaultOptions initializes a Options struct with default values.
 func NewDefaultOptions(setters ...Option) *Options {
 	opts := &Options{
 		CreateGPT: false,
+		Mode:      DefaultMode,
 	}
 
 	for _, setter := range setters {

--- a/blockdevice/probe/probe.go
+++ b/blockdevice/probe/probe.go
@@ -149,7 +149,7 @@ func probe(devpath string) (devpaths []string) {
 	// Start by opening the block device.
 	// If a partition table was not found, it is still possible that a
 	// file system exists without a partition table.
-	bd, err := blockdevice.Open(devpath)
+	bd, err := blockdevice.Open(devpath, blockdevice.WithMode(blockdevice.ReadonlyMode))
 	if err != nil {
 		//nolint: errcheck
 		if sb, _ := filesystem.Probe(devpath); sb != nil {


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/go-blockdevice/issues/44

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>