### PR TITLE
fix: gpt partition not found

### DIFF
--- a/blockdevice/blockdevice_linux.go
+++ b/blockdevice/blockdevice_linux.go
@@ -103,7 +103,13 @@ func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {
 				return nil, err
 			}
 			bd.g = g
+
+			return bd, nil
 		}
+
+		err = ErrMissingPartitionTable
+
+		return nil, err
 	}
 
 	return bd, nil


### PR DESCRIPTION
Function Open does not return error if gpt partition not found.

Talos uses GPT partition, and function blockdevice.Open return nil error even if it not found GPT partition.
Here, for example, we think that partitions do not exist if error return, but is not. It always (most of the cases) returns nil error.

https://github.com/talos-systems/go-blockdevice/blob/e367f9dc7fa935f11672de0fdc8a89429285a07a/blockdevice/probe/probe.go#L150-L160