### PR TITLE
fix: also open in readonly mode when running `All` lookup method

### DIFF
--- a/blockdevice/probe/probe.go
+++ b/blockdevice/probe/probe.go
@@ -239,7 +239,7 @@ func probePartitions(devpath string) (probed []*ProbedBlockDevice) {
 			err error
 		)
 
-		bd, err = blockdevice.Open(devpath)
+		bd, err = blockdevice.Open(devpath, blockdevice.WithMode(blockdevice.ReadonlyMode))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
This was missed out in the previous change.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>