### PR TITLE
fix: revert gpt partition not found

### DIFF
--- a/blockdevice/blockdevice_linux.go
+++ b/blockdevice/blockdevice_linux.go
@@ -103,13 +103,7 @@ func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {
 				return nil, err
 			}
 			bd.g = g
-
-			return bd, nil
 		}
-
-		err = ErrMissingPartitionTable
-
-		return nil, err
 	}
 
 	return bd, nil


### PR DESCRIPTION
This reverts commit d7d4cdd7ac56c82caab19246b5decd59f12195eb.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>