### PR TITLE
refactor: simplify middle endian functions

### DIFF
--- a/blockdevice/endianness/endianness.go
+++ b/blockdevice/endianness/endianness.go
@@ -5,90 +5,39 @@
 package endianness
 
 import (
-	"bytes"
 	"encoding/binary"
 )
 
 // ToMiddleEndian converts a byte slice representation of a UUID to a
 // middle-endian byte slice representation of a UUID.
-//
-//nolint: dupl
-func ToMiddleEndian(data []byte) (b []byte, err error) {
-	buf := bytes.NewBuffer(make([]byte, 0, 16))
+func ToMiddleEndian(data []byte) []byte {
+	b := make([]byte, 16)
 
-	timeLow := binary.BigEndian.Uint32(data[0:4])
-	if err := binary.Write(buf, binary.LittleEndian, timeLow); err != nil {
-		return nil, err
-	}
+	// timeLow
+	binary.LittleEndian.PutUint32(b, binary.BigEndian.Uint32(data[0:4]))
+	// timeMid
+	binary.LittleEndian.PutUint16(b[4:], binary.BigEndian.Uint16(data[4:6]))
+	// timeHigh
+	binary.LittleEndian.PutUint16(b[6:], binary.BigEndian.Uint16(data[6:8]))
+	// clockSeqHi,clockSeqLo,node
+	copy(b[8:], data[8:16])
 
-	timeMid := binary.BigEndian.Uint16(data[4:6])
-	if err := binary.Write(buf, binary.LittleEndian, timeMid); err != nil {
-		return nil, err
-	}
-
-	timeHigh := binary.BigEndian.Uint16(data[6:8])
-	if err := binary.Write(buf, binary.LittleEndian, timeHigh); err != nil {
-		return nil, err
-	}
-
-	clockSeqHi := data[8:9][0]
-	if err := binary.Write(buf, binary.BigEndian, clockSeqHi); err != nil {
-		return nil, err
-	}
-
-	clockSeqLow := data[9:10][0]
-	if err := binary.Write(buf, binary.BigEndian, clockSeqLow); err != nil {
-		return nil, err
-	}
-
-	node := data[10:16]
-	if err := binary.Write(buf, binary.BigEndian, node); err != nil {
-		return nil, err
-	}
-
-	b = buf.Bytes()
-
-	return b, nil
+	return b
 }
 
 // FromMiddleEndian converts a middle-endian byte slice representation of a
 // UUID to a big-endian byte slice representation of a UUID.
-//
-//nolint: dupl
-func FromMiddleEndian(data []byte) (b []byte, err error) {
-	buf := bytes.NewBuffer(make([]byte, 0, 16))
+func FromMiddleEndian(data []byte) []byte {
+	b := make([]byte, 16)
 
-	timeLow := binary.LittleEndian.Uint32(data[0:4])
-	if err := binary.Write(buf, binary.BigEndian, timeLow); err != nil {
-		return nil, err
-	}
+	// timeLow
+	binary.BigEndian.PutUint32(b, binary.LittleEndian.Uint32(data[0:4]))
+	// timeMid
+	binary.BigEndian.PutUint16(b[4:], binary.LittleEndian.Uint16(data[4:6]))
+	// timeHigh
+	binary.BigEndian.PutUint16(b[6:], binary.LittleEndian.Uint16(data[6:8]))
+	// clockSeqHi,clockSeqLo,node
+	copy(b[8:], data[8:16])
 
-	timeMid := binary.LittleEndian.Uint16(data[4:6])
-	if err := binary.Write(buf, binary.BigEndian, timeMid); err != nil {
-		return nil, err
-	}
-
-	timeHigh := binary.LittleEndian.Uint16(data[6:8])
-	if err := binary.Write(buf, binary.BigEndian, timeHigh); err != nil {
-		return nil, err
-	}
-
-	clockSeqHi := data[8:9][0]
-	if err := binary.Write(buf, binary.BigEndian, clockSeqHi); err != nil {
-		return nil, err
-	}
-
-	clockSeqLow := data[9:10][0]
-	if err := binary.Write(buf, binary.BigEndian, clockSeqLow); err != nil {
-		return nil, err
-	}
-
-	node := data[10:16]
-	if err := binary.Write(buf, binary.BigEndian, node); err != nil {
-		return nil, err
-	}
-
-	b = buf.Bytes()
-
-	return b, nil
+	return b
 }

--- a/blockdevice/endianness/endianness_test.go
+++ b/blockdevice/endianness/endianness_test.go
@@ -23,30 +23,22 @@ func TestToMiddleEndian(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		wantB   []byte
-		wantErr bool
+		name  string
+		args  args
+		wantB []byte
 	}{
 		{
 			name: "valid",
 			args: args{
 				data: uuid,
 			},
-			wantB:   middle,
-			wantErr: false,
+			wantB: middle,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotB, err := endianness.ToMiddleEndian(tt.args.data)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ToMiddleEndian() error = %v, wantErr %v", err, tt.wantErr)
-
-				return
-			}
+			gotB := endianness.ToMiddleEndian(tt.args.data)
 
 			if !reflect.DeepEqual(gotB, tt.wantB) {
 				t.Errorf("ToMiddleEndian() = %v, want %v", gotB, tt.wantB)
@@ -61,30 +53,22 @@ func TestFromMiddleEndian(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		args    args
-		wantB   []byte
-		wantErr bool
+		name  string
+		args  args
+		wantB []byte
 	}{
 		{
 			name: "valid",
 			args: args{
 				data: middle,
 			},
-			wantB:   uuid,
-			wantErr: false,
+			wantB: uuid,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotB, err := endianness.FromMiddleEndian(tt.args.data)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("FromMiddleEndian() error = %v, wantErr %v", err, tt.wantErr)
-
-				return
-			}
+			gotB := endianness.FromMiddleEndian(tt.args.data)
 
 			if !reflect.DeepEqual(gotB, tt.wantB) {
 				t.Errorf("FromMiddleEndian() = %v, want %v", gotB, tt.wantB)

--- a/blockdevice/partition/gpt/header.go
+++ b/blockdevice/partition/gpt/header.go
@@ -521,12 +521,7 @@ func (h *Header) DeserializeGUUID() (err error) {
 		return fmt.Errorf("guuid read: %w", err)
 	}
 
-	u, err := endianness.FromMiddleEndian(data)
-	if err != nil {
-		return err
-	}
-
-	guid, err := uuid.FromBytes(u)
+	guid, err := uuid.FromBytes(endianness.FromMiddleEndian(data))
 	if err != nil {
 		return fmt.Errorf("invalid GUUID: %w", err)
 	}
@@ -543,12 +538,7 @@ func (h *Header) SerializeGUUID() (err error) {
 		return err
 	}
 
-	data, err := endianness.ToMiddleEndian(b)
-	if err != nil {
-		return err
-	}
-
-	err = h.Write(data, 0x38)
+	err = h.Write(endianness.ToMiddleEndian(b), 0x38)
 	if err != nil {
 		return err
 	}

--- a/blockdevice/partition/gpt/partition.go
+++ b/blockdevice/partition/gpt/partition.go
@@ -176,12 +176,7 @@ func (p *Partition) DeserializeType(buf *lba.Buffer) (err error) {
 		return fmt.Errorf("type read: %w", err)
 	}
 
-	u, err := endianness.FromMiddleEndian(data)
-	if err != nil {
-		return err
-	}
-
-	guid, err := uuid.FromBytes(u)
+	guid, err := uuid.FromBytes(endianness.FromMiddleEndian(data))
 	if err != nil {
 		return fmt.Errorf("invalid GUUID: %w", err)
 	}
@@ -200,12 +195,7 @@ func (p *Partition) SerializeType(buf *lba.Buffer) (err error) {
 		return err
 	}
 
-	data, err := endianness.ToMiddleEndian(b)
-	if err != nil {
-		return err
-	}
-
-	err = buf.Write(data, 0x00)
+	err = buf.Write(endianness.ToMiddleEndian(b), 0x00)
 	if err != nil {
 		return err
 	}
@@ -220,12 +210,7 @@ func (p *Partition) DeserializeID(buf *lba.Buffer) (err error) {
 		return fmt.Errorf("id read: %w", err)
 	}
 
-	u, err := endianness.FromMiddleEndian(data)
-	if err != nil {
-		return err
-	}
-
-	guid, err := uuid.FromBytes(u)
+	guid, err := uuid.FromBytes(endianness.FromMiddleEndian(data))
 	if err != nil {
 		return fmt.Errorf("invalid GUUID: %w", err)
 	}
@@ -242,12 +227,7 @@ func (p *Partition) SerializeID(buf *lba.Buffer) (err error) {
 		return err
 	}
 
-	data, err := endianness.ToMiddleEndian(b)
-	if err != nil {
-		return err
-	}
-
-	err = buf.Write(data, 0x10)
+	err = buf.Write(endianness.ToMiddleEndian(b), 0x10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use optimized methods for conversion, skip conversion for byte slices
(they don't have endianness).

See also https://github.com/talos-systems/talos/issues/4686

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>