### PR TITLE
feat: implement device wiping by signatures

### DIFF
--- a/blkid/blkid.go
+++ b/blkid/blkid.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/probe"
 	"github.com/siderolabs/go-blockdevice/v2/block"
 )
 
@@ -51,10 +52,12 @@ type Info struct { //nolint:govet
 }
 
 // ProbeResult is a result of probing a single filesystem/partition.
-type ProbeResult struct { //nolint:govet
+type ProbeResult struct {
 	Name  string
 	UUID  *uuid.UUID
 	Label *string
+
+	SignatureRanges []SignatureRange
 
 	BlockSize           uint32
 	FilesystemBlockSize uint32
@@ -80,6 +83,9 @@ type NestedProbeResult struct { //nolint:govet
 
 	Parts []NestedProbeResult
 }
+
+// SignatureRange is a range of bytes for signature detection.
+type SignatureRange = probe.SignatureRange
 
 // ProbeOptions is the options for probing.
 type ProbeOptions struct {

--- a/blkid/internal/probe/probe.go
+++ b/blkid/internal/probe/probe.go
@@ -44,6 +44,8 @@ type Result struct {
 
 	Parts []Partition
 
+	ExtraSignatures []SignatureRange
+
 	BlockSize           uint32
 	FilesystemBlockSize uint32
 	ProbedSize          uint64
@@ -57,6 +59,12 @@ type Partition struct {
 
 	Index uint // 1-based index
 
+	Offset uint64
+	Size   uint64
+}
+
+// SignatureRange is a range of bytes for signature detection.
+type SignatureRange struct {
 	Offset uint64
 	Size   uint64
 }

--- a/block/wipe_linux_test.go
+++ b/block/wipe_linux_test.go
@@ -79,9 +79,17 @@ func TestDeviceWipe(t *testing.T) {
 
 	assertZeroed(t, f, 0, 1024)
 	assertZeroed(t, f, 2*GiB-1024, 1024)
+
+	_, err = f.WriteAt(magic, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, devWhole.FastWipe(block.Range{Offset: 0, Size: 4}, block.Range{Offset: 2*GiB - 4, Size: 4}))
+
+	assertZeroed(t, f, 0, 4)
+	assertZeroed(t, f, 2*GiB-4, 4)
 }
 
-func assertZeroed(t *testing.T, f *os.File, offset, length int64) { //nolint:unparam
+func assertZeroed(t *testing.T, f *os.File, offset, length int64) {
 	t.Helper()
 
 	buf := make([]byte, length)

--- a/partitioning/gpt/gpt.go
+++ b/partitioning/gpt/gpt.go
@@ -157,7 +157,7 @@ func Read(dev Device, opts ...Option) (*Table, error) {
 	}
 
 	hdr, entries, err := gptstructs.ReadHeader(dev, 1, lastLBA)
-	if err != nil {
+	if err != nil && !errors.Is(err, gptstructs.ErrZeroedHeader) { // fallback to backup header if header is zeroed
 		return nil, err
 	}
 


### PR DESCRIPTION
This allows to wipe specific signatures which are used to detect filesystems and partitions.

This is important for cases like this one:

* create a GPT partition table
* format filesystems
* wipe the whole device
* re-create GPT partition table with exactly same layout
* if the signatures for filesystems haven't been properly wiped, the filesystem will re-appear

The previous implementation only wiped first and last 1MB which enough to wipe GPT, but not all filesystems.

Probe now returns offsets of signatures to be wiped.

Fixed some bugs, including extra "recovery" of GPT from alternate header if the primary is completely zeroed out.

Fixes https://github.com/siderolabs/talos/issues/9724

Fixes https://github.com/siderolabs/talos/issues/9530