### PR TITLE
fix: make extfs filesystem detection separate for ext2/3/4

### DIFF
--- a/blkid/internal/chain/chain.go
+++ b/blkid/internal/chain/chain.go
@@ -58,7 +58,9 @@ func (chain Chain) MagicMatches(buf []byte) []probe.MagicMatch {
 func Default() Chain {
 	return Chain{
 		&xfs.Probe{},
-		&ext.Probe{},
+		&ext.Probe4{},
+		&ext.Probe3{},
+		&ext.Probe2{},
 		&vfat.Probe{},
 		&swap.Probe{},
 		&lvm2.Probe{},

--- a/blkid/internal/filesystems/ext/ext2.go
+++ b/blkid/internal/filesystems/ext/ext2.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ext
+
+import (
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/magic"
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/probe"
+)
+
+// Probe2 for ext2.
+type Probe2 struct {
+	probeCommon
+}
+
+// Name returns the name of the xfs filesystem.
+func (p *Probe2) Name() string {
+	return "ext2"
+}
+
+// Probe runs the further inspection and returns the result if successful.
+func (p *Probe2) Probe(r probe.Reader, _ magic.Magic) (*probe.Result, error) {
+	sb, err := p.readSuperblock(r)
+	if err != nil || sb == nil {
+		return nil, err
+	}
+
+	// should not have a journal
+	if sb.Get_s_feature_compat()&EXT3_FEATURE_COMPAT_HAS_JOURNAL != 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	// ext2 should not have features it doesn't understand
+	if (sb.Get_s_feature_ro_compat()&EXT2_FEATURE_RO_COMPAT_UNSUPPORTED) != 0 ||
+		(sb.Get_s_feature_incompat()&EXT2_FEATURE_INCOMPAT_UNSUPPORTED) != 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	return p.buildResult(sb)
+}

--- a/blkid/internal/filesystems/ext/ext3.go
+++ b/blkid/internal/filesystems/ext/ext3.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ext
+
+import (
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/magic"
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/probe"
+)
+
+// Probe3 for ext3.
+type Probe3 struct {
+	probeCommon
+}
+
+// Name returns the name of the xfs filesystem.
+func (p *Probe3) Name() string {
+	return "ext3"
+}
+
+// Probe runs the further inspection and returns the result if successful.
+func (p *Probe3) Probe(r probe.Reader, _ magic.Magic) (*probe.Result, error) {
+	sb, err := p.readSuperblock(r)
+	if err != nil || sb == nil {
+		return nil, err
+	}
+
+	// should have a journal
+	if sb.Get_s_feature_compat()&EXT3_FEATURE_COMPAT_HAS_JOURNAL == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	// ext3 should not have features it doesn't understand
+	if (sb.Get_s_feature_ro_compat()&EXT3_FEATURE_RO_COMPAT_UNSUPPORTED) != 0 ||
+		(sb.Get_s_feature_incompat()&EXT3_FEATURE_INCOMPAT_UNSUPPORTED) != 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	return p.buildResult(sb)
+}

--- a/blkid/internal/filesystems/ext/ext4.go
+++ b/blkid/internal/filesystems/ext/ext4.go
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ext
+
+import (
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/magic"
+	"github.com/siderolabs/go-blockdevice/v2/blkid/internal/probe"
+)
+
+// Probe4 for ext4.
+type Probe4 struct {
+	probeCommon
+}
+
+// Name returns the name of the xfs filesystem.
+func (p *Probe4) Name() string {
+	return "ext4"
+}
+
+// Probe runs the further inspection and returns the result if successful.
+func (p *Probe4) Probe(r probe.Reader, _ magic.Magic) (*probe.Result, error) {
+	sb, err := p.readSuperblock(r)
+	if err != nil || sb == nil {
+		return nil, err
+	}
+
+	// distinguish from jbd
+	if sb.Get_s_feature_incompat()&EXT3_FEATURE_INCOMPAT_JOURNAL_DEV != 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	// ext4 has at least one feature which ext3 doesn't understand
+	if (sb.Get_s_feature_ro_compat()&EXT3_FEATURE_RO_COMPAT_UNSUPPORTED) == 0 &&
+		(sb.Get_s_feature_incompat()&EXT3_FEATURE_INCOMPAT_UNSUPPORTED) == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	return p.buildResult(sb)
+}


### PR DESCRIPTION
It's import to make sure detected names match the names in `/proc/filesystems` for the actual mount call.

Part of https://github.com/siderolabs/talos/issues/9746