### PR TITLE
fix: many small fixes, mostly around overwrites

### DIFF
--- a/blkid/internal/chain/chain.go
+++ b/blkid/internal/chain/chain.go
@@ -64,12 +64,13 @@ func Default() Chain {
 		&vfat.Probe{},
 		&swap.Probe{},
 		&lvm2.Probe{},
-		&gpt.Probe{},
 		&zfs.Probe{},
 		&squashfs.Probe{},
 		&talosmeta.Probe{},
 		&luks.Probe{},
 		&iso9660.Probe{},
 		&bluestore.Probe{},
+		// keep GPT last, as if GPT is overwritten with smaller filesystem image, it should be detected first
+		&gpt.Probe{},
 	}
 }

--- a/blkid/internal/partitions/gpt/gpt.go
+++ b/blkid/internal/partitions/gpt/gpt.go
@@ -63,6 +63,12 @@ func (p *Probe) Probe(r probe.Reader, _ magic.Magic) (*probe.Result, error) {
 		if err != nil && !errors.Is(err, gptstructs.ErrZeroedHeader) { // skip zeroed out backup headers
 			return nil, err
 		}
+
+		if hdr != nil {
+			lastLBA = hdr.Get_my_lba()
+		}
+	} else {
+		lastLBA = hdr.Get_alternate_lba()
 	}
 
 	if hdr == nil {

--- a/block/wipe_linux.go
+++ b/block/wipe_linux.go
@@ -5,6 +5,7 @@
 package block
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"runtime"
@@ -82,7 +83,7 @@ func (d *Device) FastWipe(ranges ...Range) error {
 	for _, r := range ranges {
 		_, err = d.WipeRange(r.Offset, r.Size)
 		if err != nil {
-			return err
+			return fmt.Errorf("error wiping %d:+%d: %w", r.Offset, r.Size, err)
 		}
 	}
 
@@ -91,6 +92,10 @@ func (d *Device) FastWipe(ranges ...Range) error {
 
 // WipeRange the device [start, start+length).
 func (d *Device) WipeRange(start, length uint64) (string, error) {
+	if length == 0 {
+		return "noop", nil
+	}
+
 	// verify alignment before starting to use ioctl ways
 	if start&0x7ff == 0 && length&0x7ff == 0 {
 		r := [2]uint64{start, length}


### PR DESCRIPTION
1. Push GPT discovery last in the chain - if the GPT image is overridden with a smaller filesystem image, it might detect GPT before actual filesystem.

2. Fix GPT secondary header signature calculation - it might be not the end of the disk.

3. Add more tests for wipe by signatures and detection.

Related to, but doesn't fix https://github.com/siderolabs/talos/issues/9852