### PR TITLE
fix: chain of probe functions

### DIFF
--- a/blkid/blkid_linux_test.go
+++ b/blkid/blkid_linux_test.go
@@ -708,6 +708,16 @@ func corruptGPT(f func(*testing.T, string)) func(*testing.T, string) {
 	}
 }
 
+func gptOverwritesFilesystem(f func(*testing.T, string)) func(*testing.T, string) {
+	return func(t *testing.T, path string) {
+		t.Helper()
+
+		f(t, path)
+
+		setupGPT(t, path)
+	}
+}
+
 func wipe1MB(f func(*testing.T, string)) func(*testing.T, string) {
 	return func(t *testing.T, path string) {
 		t.Helper()
@@ -805,6 +815,26 @@ func TestProbePathGPT(t *testing.T) {
 
 			size:  2 * GiB,
 			setup: setupGPT,
+
+			expectedSize:  2 * GiB,
+			expectedUUID:  uuid.MustParse("DDDA0816-8B53-47BF-A813-9EBB1F73AAA2"),
+			expectedParts: expectedParts,
+			expectedSignatures: []blkid.SignatureRange{
+				{
+					Offset: 512,
+					Size:   512,
+				},
+				{
+					Offset: 2147483136,
+					Size:   512,
+				},
+			},
+		},
+		{
+			name: "GPT overwrites ZFS",
+
+			size:  2 * GiB,
+			setup: gptOverwritesFilesystem(zfsSetup),
 
 			expectedSize:  2 * GiB,
 			expectedUUID:  uuid.MustParse("DDDA0816-8B53-47BF-A813-9EBB1F73AAA2"),

--- a/blkid/internal/chain/chain.go
+++ b/blkid/internal/chain/chain.go
@@ -62,15 +62,14 @@ func Default() Chain {
 		&ext.Probe3{},
 		&ext.Probe2{},
 		&vfat.Probe{},
+		&iso9660.Probe{},
+		&squashfs.Probe{},
+		&talosmeta.Probe{},
+		&gpt.Probe{},
+		&bluestore.Probe{},
+		&luks.Probe{},
 		&swap.Probe{},
 		&lvm2.Probe{},
 		&zfs.Probe{},
-		&squashfs.Probe{},
-		&talosmeta.Probe{},
-		&luks.Probe{},
-		&iso9660.Probe{},
-		&bluestore.Probe{},
-		// keep GPT last, as if GPT is overwritten with smaller filesystem image, it should be detected first
-		&gpt.Probe{},
 	}
 }


### PR DESCRIPTION
Adjust the order of probing once again:

* push up probes which have a strict magic match (xfs, extfs, squashfs, etc.), and for filesystems which are commonly used in Talos
* keep GPT after that, as it doesn't have strict magic, but still should come early enough before other probes
* ZFS has a very wide way of looking for a superblock, which might match ZFS at the end of the disk in a partition, while the disk is actually GPT, so keep it low (and it's only an optional extension)

See https://github.com/siderolabs/talos/issues/10069