### PR TITLE
fix: allow sector size override when probing a file

### DIFF
--- a/blkid/blkid.go
+++ b/blkid/blkid.go
@@ -93,6 +93,8 @@ type ProbeOptions struct {
 	Logger *zap.Logger
 	// SkipLocking blockdevices in shared mode.
 	SkipLocking bool
+	// SectorSize is the sector size to use for probing.
+	SectorSize uint
 }
 
 // ProbeOption is an option for probing.
@@ -112,9 +114,19 @@ func WithSkipLocking(skip bool) ProbeOption {
 	}
 }
 
+// WithSectorSize sets the sector size to use for probing.
+//
+// This is useful when probing a file that is not a blockdevice.
+func WithSectorSize(sectorSize uint) ProbeOption {
+	return func(o *ProbeOptions) {
+		o.SectorSize = sectorSize
+	}
+}
+
 func applyProbeOptions(opts ...ProbeOption) ProbeOptions {
 	o := ProbeOptions{
-		Logger: zap.NewNop(),
+		Logger:     zap.NewNop(),
+		SectorSize: block.DefaultBlockSize,
 	}
 
 	for _, opt := range opts {

--- a/blkid/blkid_linux.go
+++ b/blkid/blkid_linux.go
@@ -82,8 +82,8 @@ func Probe(f *os.File, opts ...ProbeOption) (*Info, error) {
 	case unix.S_IFREG:
 		// regular file (an image?), so use different settings
 		info.Size = uint64(st.Size())
-		info.IOSize = block.DefaultBlockSize
-		info.SectorSize = block.DefaultBlockSize
+		info.SectorSize = options.SectorSize
+		info.IOSize = info.SectorSize
 	default:
 		return nil, fmt.Errorf("unsupported file type: %s", st.Mode().Type())
 	}


### PR DESCRIPTION
This allows to probe disk images with sector size which is not 512.