### PR TITLE
fix: revert setting first usable LBA to 1024

### DIFF
--- a/partitioning/gpt/gpt.go
+++ b/partitioning/gpt/gpt.go
@@ -266,7 +266,6 @@ func (t *Table) init(lastLBA uint64) {
 	t.alignment = uint64((alignmentSize + t.sectorSize - 1) / t.sectorSize) // 2048 with 512 sector size, 256 with 4096 sector size
 
 	t.firstUsableLBA = (t.firstUsableLBA + t.alignment - 1) / t.alignment * t.alignment // 2048 with 512 sector size, 256 with 4096 sector size
-	t.firstUsableLBA = max(t.firstUsableLBA, 1024)                                      // make first usable LBA at least 1024 to avoid issues with some BIOSes
 }
 
 // Clear the partition table.


### PR DESCRIPTION
This turned out to be red herring, first usable LBA for 4k disks should be 256 (same 1 MiB alignment).