### PR TITLE
fix: bring block device uuid back

### DIFF
--- a/block/device.go
+++ b/block/device.go
@@ -52,6 +52,7 @@ type DeviceProperties struct {
 	// WWID /sys/block/<dev>/wwid.
 	WWID string
 	// UUID /sys/block/<dev>/uuid.
+	UUID string
 	// BusPath PCI bus path.
 	BusPath string
 	// SubSystem is the dest path of symlink /sys/block/<dev>/subsystem.

--- a/block/device_linux.go
+++ b/block/device_linux.go
@@ -344,10 +344,15 @@ func (d *Device) GetProperties() (*DeviceProperties, error) {
 		Serial:   readSysFsFile(filepath.Join(sysFsPath, "serial")),
 		Modalias: readSysFsFile(filepath.Join(sysFsPath, "device", "modalias")),
 		WWID:     readSysFsFile(filepath.Join(sysFsPath, "wwid")),
+		UUID:     readSysFsFile(filepath.Join(sysFsPath, "uuid")),
 	}
 
 	if props.WWID == "" {
 		props.WWID = readSysFsFile(filepath.Join(sysFsPath, "device", "wwid"))
+	}
+
+	if props.UUID == "" {
+		props.UUID = readSysFsFile(filepath.Join(sysFsPath, "device", "uuid"))
 	}
 
 	if props.Serial == "" {


### PR DESCRIPTION
It looks like it's actually being used, see https://github.com/siderolabs/talos/issues/10182