### PR TITLE
fix: wipe (P)MBR with GPT

### DIFF
--- a/blkid/blkid_linux_test.go
+++ b/blkid/blkid_linux_test.go
@@ -821,8 +821,8 @@ func TestProbePathGPT(t *testing.T) {
 			expectedParts: expectedParts,
 			expectedSignatures: []blkid.SignatureRange{
 				{
-					Offset: 512,
-					Size:   512,
+					Offset: 0,
+					Size:   1024,
 				},
 				{
 					Offset: 2147483136,
@@ -841,8 +841,8 @@ func TestProbePathGPT(t *testing.T) {
 			expectedParts: expectedParts,
 			expectedSignatures: []blkid.SignatureRange{
 				{
-					Offset: 512,
-					Size:   512,
+					Offset: 0,
+					Size:   1024,
 				},
 				{
 					Offset: 2147483136,
@@ -861,8 +861,8 @@ func TestProbePathGPT(t *testing.T) {
 			expectedParts: expectedParts,
 			expectedSignatures: []blkid.SignatureRange{
 				{
-					Offset: 512,
-					Size:   512,
+					Offset: 0,
+					Size:   1024,
 				},
 				{
 					Offset: 2147483136,
@@ -902,8 +902,8 @@ func TestProbePathGPT(t *testing.T) {
 			},
 			expectedSignatures: []blkid.SignatureRange{
 				{
-					Offset: 512,
-					Size:   512,
+					Offset: 0,
+					Size:   1024,
 				},
 				{
 					Offset: 536870400,
@@ -1074,8 +1074,8 @@ func TestProbePathNested(t *testing.T) {
 			expectedParts: expectedParts,
 			expectedSignatures: []blkid.SignatureRange{
 				{
-					Offset: 512,
-					Size:   512,
+					Offset: 0,
+					Size:   1024,
 				},
 				{
 					Offset: 2147483136,

--- a/blkid/internal/partitions/gpt/gpt.go
+++ b/blkid/internal/partitions/gpt/gpt.go
@@ -91,8 +91,8 @@ func (p *Probe) Probe(r probe.Reader, _ magic.Magic) (*probe.Result, error) {
 
 		ExtraSignatures: []probe.SignatureRange{
 			{
-				Offset: primaryLBA * uint64(sectorSize),
-				Size:   uint64(sectorSize),
+				Offset: 0, // wipe both (P)MBR and first LBA with GPT header
+				Size:   2 * uint64(sectorSize),
 			},
 			{
 				Offset: lastLBA * uint64(sectorSize),


### PR DESCRIPTION
When wiping GPT, also wipe the zeroth sector with MBR.