### PR TITLE
fix: partition allocation index

### DIFF
--- a/partitioning/gpt/gpt.go
+++ b/partitioning/gpt/gpt.go
@@ -393,14 +393,23 @@ func (t *Table) AllocatePartition(size uint64, name string, partType uuid.UUID, 
 	}
 
 	if smallestRange.partitionIdx > 0 && t.entries[smallestRange.partitionIdx-1] == nil {
-		t.entries[smallestRange.partitionIdx-1] = entry
-	} else {
-		t.entries = slices.Insert(
-			t.entries,
-			smallestRange.partitionIdx,
-			entry,
-		)
+		// find the smallest non-empty partition
+		newPartitionIdx := smallestRange.partitionIdx - 1
+
+		for newPartitionIdx > 0 && t.entries[newPartitionIdx-1] == nil {
+			newPartitionIdx--
+		}
+
+		t.entries[newPartitionIdx] = entry
+
+		return newPartitionIdx + 1, *entry, nil
 	}
+
+	t.entries = slices.Insert(
+		t.entries,
+		smallestRange.partitionIdx,
+		entry,
+	)
 
 	return smallestRange.partitionIdx + 1, *entry, nil
 }

--- a/partitioning/gpt/testdata/mix-allocate.gdisk
+++ b/partitioning/gpt/testdata/mix-allocate.gdisk
@@ -16,7 +16,7 @@ Total free space is 4085727 sectors (1.9 GiB)
 
 Number  Start (sector)    End (sector)  Size       Code  Name
    1            2048         2099199   1024.0 MiB  EF00  1G1
-   3         2099200         5171199   1.5 GiB     8E00  1500M
+   2         2099200         5171199   1.5 GiB     8E00  1500M
    4         6293504         8390655   1024.0 MiB  8E00  1G4
    5         8390656         8800255   200.0 MiB   8E00  200M
    6         8800256         9619455   400.0 MiB   8E00  400M


### PR DESCRIPTION
This fixes two issues:

* the returned index for allocated partition in the "middle" was off by one
* when allocating partition re-using partition slot, also use the smallest slot available, so that the next allocation can also re-use the slot

There is one more issue for the future - we should add a flag to disallow moving existing partitions in case any of them are mounted at the moment.

See https://github.com/siderolabs/talos/issues/10368