### PR TITLE
Feat/validate detached luks header

### DIFF
--- a/encryption/luks/luks.go
+++ b/encryption/luks/luks.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -116,6 +117,8 @@ type LUKS struct {
 	pbkdfMemory          uint64
 	blockSize            uint64
 	keySize              uint
+	detachedHeaderDir    string
+	validationPolicy     ValidationPolicy
 }
 
 // New creates new LUKS2 encryption provider.
@@ -137,13 +140,52 @@ func New(cipher Cipher, options ...Option) *LUKS {
 
 // Open runs luksOpen on a device and returns mapped device path.
 func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *encryption.Key) (string, error) {
+	if l.detachedHeaderDir == "" {
+		return "", fmt.Errorf("detached header dir is not configured")
+	}
+
+	policy := l.validationPolicy
+	if policy.AllowedSegmentEncryptions == nil {
+		cipher, err := l.cipher.String()
+		if err != nil {
+			return "", err
+		}
+
+		policy.AllowedSegmentEncryptions = []string{cipher}
+	}
+
+	headerFile, err := createDetachedHeaderFile(l.detachedHeaderDir)
+	if err != nil {
+		return "", err
+	}
+
+	headerPath := headerFile.Name()
+	_ = headerFile.Close()
+
+	defer func() {
+		_ = os.Remove(headerPath)
+	}()
+
+	if _, err = l.runCommand(ctx, []string{"luksHeaderBackup", deviceName, "--header-backup-file", headerPath}, nil); err != nil {
+		return "", err
+	}
+
+	metadata, err := l.dumpJSONMetadata(ctx, headerPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err = validateLUKS2JSONMetadata(metadata, policy); err != nil {
+		return "", err
+	}
+
 	args := slices.Concat(
-		[]string{"luksOpen", deviceName, mappedName, "--key-file=-"},
+		[]string{"luksOpen", "--header", headerPath, deviceName, mappedName, "--key-file=-"},
 		keyslotArgs(key),
 		l.perfArgs(),
 	)
 
-	_, err := l.runCommand(ctx, args, key.Value)
+	_, err = l.runCommand(ctx, args, key.Value)
 	if err != nil {
 		return "", err
 	}
@@ -173,7 +215,6 @@ func (l *LUKS) Encrypt(ctx context.Context, deviceName string, key *encryption.K
 	if err != nil {
 		return err
 	}
-
 	args := slices.Concat(
 		[]string{"luksFormat", "--type", "luks2", "--key-file=-", "-c", cipher, deviceName},
 		l.argonArgs(),

--- a/encryption/luks/luks.go
+++ b/encryption/luks/luks.go
@@ -162,7 +162,11 @@ func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *enc
 	headerPath := headerFile.Name()
 	_ = headerFile.Close()
 
+	// Remove temp file so cryptsetup can create a fresh header backup at this path.
+	_ = os.Remove(headerPath)
+
 	defer func() {
+		// Clean up the header backup file created by cryptsetup.
 		_ = os.Remove(headerPath)
 	}()
 

--- a/encryption/luks/options.go
+++ b/encryption/luks/options.go
@@ -50,3 +50,17 @@ func WithPerfOptions(options ...string) Option {
 		l.perfOptions = options
 	}
 }
+
+// WithDetachedHeaderDir sets the directory where detached LUKS header files are created.
+func WithDetachedHeaderDir(dir string) Option {
+	return func(l *LUKS) {
+		l.detachedHeaderDir = dir
+	}
+}
+
+// WithValidationPolicy overrides the default detached-header validation policy.
+func WithValidationPolicy(policy ValidationPolicy) Option {
+	return func(l *LUKS) {
+		l.validationPolicy = policy
+	}
+}

--- a/encryption/luks/validation.go
+++ b/encryption/luks/validation.go
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package luks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// ErrMetadataRejected is returned when detached-header validation rejects the LUKS metadata.
+var ErrMetadataRejected = errors.New("luks metadata rejected")
+
+// ValidationPolicy controls which LUKS2 metadata settings are considered acceptable.
+type ValidationPolicy struct {
+	AllowedSegmentEncryptions []string
+	AllowSegmentFlags bool
+}
+
+type luks2JSONMetadata struct {
+	Keyslots map[string]luks2JSONKeyslot `json:"keyslots"`
+	Segments map[string]luks2JSONSegment `json:"segments"`
+	Tokens   map[string]json.RawMessage  `json:"tokens"`
+}
+
+type luks2JSONKeyslot struct {
+	Type string `json:"type"`
+	Area struct {
+		Encryption string `json:"encryption"`
+	} `json:"area"`
+}
+
+type luks2JSONSegment struct {
+	Type       string   `json:"type"`
+	Encryption string   `json:"encryption"`
+	Flags      []string `json:"flags"`
+}
+
+func isNullCipher(enc string) bool {
+	enc = strings.ToLower(enc)
+	return strings.Contains(enc, "cipher_null")
+}
+
+func validateLUKS2JSONMetadata(metadata *luks2JSONMetadata, policy ValidationPolicy) error {
+	if metadata == nil {
+		return fmt.Errorf("%w: nil metadata", ErrMetadataRejected)
+	}
+
+	if len(metadata.Segments) == 0 {
+		return fmt.Errorf("%w: missing segments", ErrMetadataRejected)
+	}
+
+	seenCrypt := false
+
+	for id, segment := range metadata.Segments {
+		if segment.Type != "crypt" {
+			return fmt.Errorf("%w: unsupported segment type %q (segment %q)", ErrMetadataRejected, segment.Type, id)
+		}
+
+		seenCrypt = true
+
+		if segment.Encryption == "" {
+			return fmt.Errorf("%w: missing segment encryption (segment %q)", ErrMetadataRejected, id)
+		}
+
+		if isNullCipher(segment.Encryption) {
+			return fmt.Errorf("%w: null cipher segment encryption %q (segment %q)", ErrMetadataRejected, segment.Encryption, id)
+		}
+
+		if policy.AllowedSegmentEncryptions != nil && !slices.Contains(policy.AllowedSegmentEncryptions, segment.Encryption) {
+			return fmt.Errorf("%w: segment encryption %q is not allowed", ErrMetadataRejected, segment.Encryption)
+		}
+
+		if !policy.AllowSegmentFlags && len(segment.Flags) > 0 {
+			return fmt.Errorf("%w: segment contains flags %v (segment %q)", ErrMetadataRejected, segment.Flags, id)
+		}
+	}
+
+	if !seenCrypt {
+		return fmt.Errorf("%w: no crypt segments present", ErrMetadataRejected)
+	}
+
+	for id, slot := range metadata.Keyslots {
+		if slot.Type != "luks2" {
+			return fmt.Errorf("%w: unsupported keyslot type %q (keyslot %q)", ErrMetadataRejected, slot.Type, id)
+		}
+
+		if slot.Area.Encryption != "" && isNullCipher(slot.Area.Encryption) {
+			return fmt.Errorf("%w: null cipher keyslot encryption %q (keyslot %q)", ErrMetadataRejected, slot.Area.Encryption, id)
+		}
+	}
+
+	return nil
+}
+
+func createDetachedHeaderFile(dir string) (*os.File, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("detached header dir is empty")
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create detached header dir %q: %w", dir, err)
+	}
+
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat detached header dir %q: %w", dir, err)
+	}
+
+	if !fi.IsDir() {
+		return nil, fmt.Errorf("detached header dir %q is not a directory", dir)
+	}
+
+	if fi.Mode().Perm()&0o022 != 0 {
+		return nil, fmt.Errorf("detached header dir %q is writable by non-owner (mode %o)", dir, fi.Mode().Perm())
+	}
+
+	f, err := os.CreateTemp(dir, "luks-header-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create detached header file in %q: %w", dir, err)
+	}
+
+	if err = f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("failed to chmod detached header file %q: %w", f.Name(), err)
+	}
+
+	return f, nil
+}
+
+func (l *LUKS) dumpJSONMetadata(ctx context.Context, headerPath string) (*luks2JSONMetadata, error) {
+	stdout, err := l.runCommand(ctx, []string{"luksDump", "--type", "luks2", "--dump-json-metadata", headerPath}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata luks2JSONMetadata
+
+	if err = json.Unmarshal([]byte(stdout), &metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse luks json metadata: %w", err)
+	}
+
+	return &metadata, nil
+}

--- a/encryption/luks/validation_test.go
+++ b/encryption/luks/validation_test.go
@@ -1,0 +1,137 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package luks
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateLUKS2JSONMetadata_AllowsConfiguredCipher(t *testing.T) {
+	metadata := &luks2JSONMetadata{
+		Keyslots: map[string]luks2JSONKeyslot{
+			"0": {
+				Type: "luks2",
+				Area: struct {
+					Encryption string `json:"encryption"`
+				}{Encryption: "aes-xts-plain64"},
+			},
+		},
+		Segments: map[string]luks2JSONSegment{
+			"0": {
+				Type:       "crypt",
+				Encryption: "aes-xts-plain64",
+			},
+		},
+	}
+
+	policy := ValidationPolicy{AllowedSegmentEncryptions: []string{"aes-xts-plain64"}}
+
+	if err := validateLUKS2JSONMetadata(metadata, policy); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateLUKS2JSONMetadata_RejectsNullCipherSegment(t *testing.T) {
+	metadata := &luks2JSONMetadata{
+		Keyslots: map[string]luks2JSONKeyslot{
+			"0": {Type: "luks2"},
+		},
+		Segments: map[string]luks2JSONSegment{
+			"0": {
+				Type:       "crypt",
+				Encryption: "cipher_null-ecb",
+			},
+		},
+	}
+
+	err := validateLUKS2JSONMetadata(metadata, ValidationPolicy{AllowedSegmentEncryptions: []string{"cipher_null-ecb"}})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if !errors.Is(err, ErrMetadataRejected) {
+		t.Fatalf("expected ErrMetadataRejected, got %v", err)
+	}
+}
+
+func TestValidateLUKS2JSONMetadata_RejectsUnexpectedCipher(t *testing.T) {
+	metadata := &luks2JSONMetadata{
+		Keyslots: map[string]luks2JSONKeyslot{
+			"0": {Type: "luks2"},
+		},
+		Segments: map[string]luks2JSONSegment{
+			"0": {
+				Type:       "crypt",
+				Encryption: "xchacha20,aes-adiantum-plain64",
+			},
+		},
+	}
+
+	err := validateLUKS2JSONMetadata(metadata, ValidationPolicy{AllowedSegmentEncryptions: []string{"aes-xts-plain64"}})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	if !errors.Is(err, ErrMetadataRejected) {
+		t.Fatalf("expected ErrMetadataRejected, got %v", err)
+	}
+}
+
+func TestCreateDetachedHeaderFile_RejectsGroupWritableDir(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chmod(dir, 0o770); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	_, err := createDetachedHeaderFile(dir)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCreateDetachedHeaderFile_RejectsSymlink(t *testing.T) {
+	target := t.TempDir()
+	linkParent := t.TempDir()
+	linkPath := filepath.Join(linkParent, "hdr")
+
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := createDetachedHeaderFile(linkPath)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCreateDetachedHeaderFile_Creates0600File(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	f, err := createDetachedHeaderFile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(f.Name())
+		_ = f.Close()
+	})
+
+	st, err := os.Stat(f.Name())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	if st.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600, got %o", st.Mode().Perm())
+	}
+}


### PR DESCRIPTION
Partly resolves: https://github.com/siderolabs/talos/issues/12105 (needs talos changes as well)

Validates LUKS header (metadata) using detached-header mode as per:
https://blog.trailofbits.com/2025/10/30/vulnerabilities-in-luks2-disk-encryption-for-confidential-vms/