### PR TITLE
fix: handle encryption keys with newline in AddKey 

### DIFF
--- a/encryption/luks/luks.go
+++ b/encryption/luks/luks.go
@@ -138,7 +138,13 @@ func New(cipher Cipher, options ...Option) *LUKS {
 // Open runs luksOpen on a device and returns mapped device path.
 func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *encryption.Key) (string, error) {
 	args := slices.Concat(
-		[]string{"luksOpen", deviceName, mappedName, "--key-file=-"},
+		[]string{
+			"luksOpen",
+			deviceName,
+			mappedName,
+			"--key-file=-",
+			fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
+		},
 		keyslotArgs(key),
 		l.perfArgs(),
 	)
@@ -175,7 +181,14 @@ func (l *LUKS) Encrypt(ctx context.Context, deviceName string, key *encryption.K
 	}
 
 	args := slices.Concat(
-		[]string{"luksFormat", "--type", "luks2", "--key-file=-", "-c", cipher, deviceName},
+		[]string{
+			"luksFormat",
+			"--type", "luks2",
+			"--key-file=-",
+			fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
+			"-c", cipher,
+			deviceName,
+		},
 		l.argonArgs(),
 		keyslotArgs(key),
 		l.encryptionArgs(),
@@ -192,7 +205,12 @@ func (l *LUKS) Encrypt(ctx context.Context, deviceName string, key *encryption.K
 
 // Resize implements encryption.Provider.
 func (l *LUKS) Resize(ctx context.Context, devname string, key *encryption.Key) error {
-	args := []string{"resize", devname, "--key-file=-"}
+	args := []string{
+		"resize",
+		devname,
+		"--key-file=-",
+		fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
+	}
 
 	_, err := l.runCommand(ctx, args, key.Value)
 
@@ -219,6 +237,8 @@ func (l *LUKS) AddKey(ctx context.Context, devname string, key, newKey *encrypti
 			devname,
 			"--key-file=-",
 			fmt.Sprintf("--keyfile-size=%d", keyfileLen),
+			"--new-keyfile=-",
+			fmt.Sprintf("--new-keyfile-size=%d", len(newKey.Value)),
 		},
 		l.argonArgs(),
 		l.encryptionArgs(),
@@ -230,38 +250,16 @@ func (l *LUKS) AddKey(ctx context.Context, devname string, key, newKey *encrypti
 	return err
 }
 
-// SetKey sets new key value at the LUKS encryption slot.
-func (l *LUKS) SetKey(ctx context.Context, devname string, oldKey, newKey *encryption.Key) error {
-	if oldKey.Slot != newKey.Slot {
-		return fmt.Errorf("old and new key slots must match")
-	}
-
-	var buffer bytes.Buffer
-
-	keyfileLen, _ := buffer.Write(oldKey.Value)
-	buffer.Write(newKey.Value)
-
-	args := slices.Concat(
-		[]string{
-			"luksChangeKey",
-			devname,
-			"--key-file=-",
-			fmt.Sprintf("--key-slot=%d", newKey.Slot),
-			fmt.Sprintf("--keyfile-size=%d", keyfileLen),
-		},
-		l.argonArgs(),
-		l.perfArgs(),
-	)
-
-	_, err := l.runCommand(ctx, args, buffer.Bytes())
-
-	return err
-}
-
 // CheckKey checks if the key is valid.
 func (l *LUKS) CheckKey(ctx context.Context, devname string, key *encryption.Key) (bool, error) {
 	args := slices.Concat(
-		[]string{"luksOpen", "--test-passphrase", devname, "--key-file=-"},
+		[]string{
+			"luksOpen",
+			"--test-passphrase",
+			devname,
+			"--key-file=-",
+			fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
+		},
 		keyslotArgs(key),
 	)
 
@@ -279,7 +277,13 @@ func (l *LUKS) CheckKey(ctx context.Context, devname string, key *encryption.Key
 
 // RemoveKey removes a key at the specified LUKS encryption slot.
 func (l *LUKS) RemoveKey(ctx context.Context, devname string, slot int, key *encryption.Key) error {
-	_, err := l.runCommand(ctx, []string{"luksKillSlot", devname, strconv.Itoa(slot), "--key-file=-"}, key.Value)
+	_, err := l.runCommand(ctx, []string{
+		"luksKillSlot",
+		devname,
+		strconv.Itoa(slot),
+		"--key-file=-",
+		fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
+	}, key.Value)
 	if err != nil {
 		return err
 	}

--- a/encryption/luks/luks_test.go
+++ b/encryption/luks/luks_test.go
@@ -6,7 +6,9 @@ package luks_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
+	"io"
 	randv2 "math/rand/v2"
 	"os"
 	"os/exec"
@@ -31,7 +33,15 @@ const (
 	size = 1024 * 1024 * 512
 )
 
-func testEncrypt(t *testing.T) {
+func TestLUKSEncrypt(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("can't run the test as non-root")
+	}
+
+	if hostname, _ := os.Hostname(); hostname == "buildkitsandbox" { //nolint:errcheck
+		t.Skip("test not supported under buildkit as partition devices are not propagated from /dev")
+	}
+
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 
@@ -88,7 +98,7 @@ func testEncrypt(t *testing.T) {
 	var _ encryption.Provider = &luks.LUKS{}
 
 	key := encryption.NewKey(0, []byte("changeme"))
-	keyExtra := encryption.NewKey(1, []byte("helloworld"))
+	keyExtra := encryption.NewKey(1, []byte("hello\nworld"))
 
 	provider := luks.New(
 		luks.AESXTSPlain64Cipher,
@@ -122,7 +132,6 @@ func testEncrypt(t *testing.T) {
 	require.NoError(t, provider.Resize(ctx, encryptedPath, key))
 
 	require.NoError(t, provider.AddKey(ctx, path, key, keyExtra))
-	require.NoError(t, provider.SetKey(ctx, path, keyExtra, keyExtra))
 
 	valid, err := provider.CheckKey(ctx, path, keyExtra)
 	require.NoError(t, err)
@@ -214,16 +223,99 @@ func testEncrypt(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLUKS(t *testing.T) {
+func TestLUKSKeyRotation(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("can't run the test as non-root")
 	}
 
-	if hostname, _ := os.Hostname(); hostname == "buildkitsandbox" { //nolint:errcheck
-		t.Skip("test not supported under buildkit as partition devices are not propagated from /dev")
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	tmpDir := t.TempDir()
+
+	rawImage := filepath.Join(tmpDir, "image.raw")
+
+	f, err := os.Create(rawImage)
+	require.NoError(t, err)
+
+	require.NoError(t, f.Truncate(int64(size)))
+	require.NoError(t, f.Close())
+
+	loDev := losetupAttachHelper(t, rawImage, false)
+
+	t.Cleanup(func() {
+		assert.NoError(t, loDev.Detach())
+	})
+
+	devPath := loDev.Path()
+	mappedName := filepath.Base(devPath) + "-encrypted"
+
+	t.Logf("unencrypted partition path %s", devPath)
+
+	keys := [][]byte{ //nolint:prealloc // this is a test
+		[]byte("topsecretlongsecretprettymuch"),
+		[]byte("keywith\nnewlines\nandstuff"),
+		[]byte("short"),
 	}
 
-	t.Run("Encrypt", testEncrypt)
+	randomKey := make([]byte, 64)
+
+	_, err = io.ReadFull(rand.Reader, randomKey)
+	require.NoError(t, err)
+
+	keys = append(keys, randomKey)
+
+	provider := luks.New(
+		luks.AESXTSPlain64Cipher,
+		luks.WithIterTime(time.Millisecond*100),
+		luks.WithPerfOptions(luks.PerfSameCPUCrypt),
+	)
+
+	oldKey := &encryption.Key{
+		Value: keys[0],
+		Slot:  0,
+	}
+
+	// encrypt with the first key
+	require.NoError(t, provider.Encrypt(ctx, devPath, oldKey))
+
+	encryptedPath, err := provider.Open(ctx, devPath, mappedName, oldKey)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, provider.Close(context.Background(), encryptedPath))
+	})
+
+	for _, newKeyValue := range keys[1:] {
+		t.Logf("rotating key to %q", newKeyValue)
+
+		newKey := &encryption.Key{
+			Value: newKeyValue,
+			Slot:  (oldKey.Slot + 1) % 2, // rotate between slot 0 and 1
+		}
+
+		// add new key
+		require.NoError(t, provider.AddKey(ctx, devPath, oldKey, newKey))
+
+		// both keys should be valid now
+		valid, err := provider.CheckKey(ctx, devPath, newKey)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		valid, err = provider.CheckKey(ctx, devPath, oldKey)
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		// drop old key
+		require.NoError(t, provider.RemoveKey(ctx, devPath, oldKey.Slot, newKey))
+
+		// old key should be invalid now
+		valid, err = provider.CheckKey(ctx, devPath, oldKey)
+		require.NoError(t, err)
+		require.False(t, valid)
+
+		oldKey = newKey
+	}
 }
 
 func losetupAttachHelper(t *testing.T, rawImage string, readonly bool) losetup.Device {

--- a/encryption/provider.go
+++ b/encryption/provider.go
@@ -26,7 +26,6 @@ type Provider interface {
 	Open(ctx context.Context, devname, mappedName string, key *Key) (string, error)
 	Close(ctx context.Context, devname string) error
 	AddKey(ctx context.Context, devname string, key, newKey *Key) error
-	SetKey(ctx context.Context, devname string, key, newKey *Key) error
 	CheckKey(ctx context.Context, devname string, key *Key) (bool, error)
 	RemoveKey(ctx context.Context, devname string, slot int, key *Key) error
 	ReadKeyslots(deviceName string) (*Keyslots, error)


### PR DESCRIPTION
Without proper flags to `cryptsetup`, it stops reading the key after the first `\n` which cuts the encryption key (if it contains that character), rendering the key unusable.

I dropped the `SetKey` method, as it doesn't seem to be used in Talos, and I can't make `cryptsetup` handle `\n` correctly there.