### PR TITLE
fix: token read truncation via go-cmd

### DIFF
--- a/encryption/luks/luks.go
+++ b/encryption/luks/luks.go
@@ -149,7 +149,7 @@ func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *enc
 		l.perfArgs(),
 	)
 
-	_, err := l.runCommand(ctx, args, key.Value)
+	_, err := l.runCommand(ctx, args, key.Value, false)
 	if err != nil {
 		return "", err
 	}
@@ -161,7 +161,7 @@ func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *enc
 func (l *LUKS) IsOpen(ctx context.Context, _, mappedName string) (bool, string, error) {
 	args := []string{"status", mappedName}
 
-	_, err := l.runCommand(ctx, args, nil)
+	_, err := l.runCommand(ctx, args, nil, false)
 	if err != nil {
 		if errors.Is(err, encryption.ErrDeviceNotReady) {
 			return false, "", nil
@@ -198,7 +198,7 @@ func (l *LUKS) Encrypt(ctx context.Context, deviceName string, key *encryption.K
 		args = append(args, fmt.Sprintf("--sector-size=%d", l.blockSize))
 	}
 
-	_, err = l.runCommand(ctx, args, key.Value)
+	_, err = l.runCommand(ctx, args, key.Value, false)
 
 	return err
 }
@@ -212,14 +212,14 @@ func (l *LUKS) Resize(ctx context.Context, devname string, key *encryption.Key) 
 		fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
 	}
 
-	_, err := l.runCommand(ctx, args, key.Value)
+	_, err := l.runCommand(ctx, args, key.Value, false)
 
 	return err
 }
 
 // Close implements encryption.Provider.
 func (l *LUKS) Close(ctx context.Context, devname string) error {
-	_, err := l.runCommand(ctx, []string{"luksClose", devname}, nil)
+	_, err := l.runCommand(ctx, []string{"luksClose", devname}, nil, false)
 
 	return err
 }
@@ -245,7 +245,7 @@ func (l *LUKS) AddKey(ctx context.Context, devname string, key, newKey *encrypti
 		keyslotArgs(newKey),
 	)
 
-	_, err := l.runCommand(ctx, args, buffer.Bytes())
+	_, err := l.runCommand(ctx, args, buffer.Bytes(), false)
 
 	return err
 }
@@ -263,7 +263,7 @@ func (l *LUKS) CheckKey(ctx context.Context, devname string, key *encryption.Key
 		keyslotArgs(key),
 	)
 
-	_, err := l.runCommand(ctx, args, key.Value)
+	_, err := l.runCommand(ctx, args, key.Value, false)
 	if err != nil {
 		if err == encryption.ErrEncryptionKeyRejected { //nolint:errorlint
 			return false, nil
@@ -283,7 +283,7 @@ func (l *LUKS) RemoveKey(ctx context.Context, devname string, slot int, key *enc
 		strconv.Itoa(slot),
 		"--key-file=-",
 		fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
-	}, key.Value)
+	}, key.Value, false)
 	if err != nil {
 		return err
 	}
@@ -337,14 +337,14 @@ func (l *LUKS) SetToken(ctx context.Context, devname string, slot int, token tok
 
 	id := strconv.Itoa(slot)
 
-	_, err = l.runCommand(ctx, []string{"token", "import", "-q", devname, "--token-id", id, "--json-file=-", "--token-replace"}, data)
+	_, err = l.runCommand(ctx, []string{"token", "import", "-q", devname, "--token-id", id, "--json-file=-", "--token-replace"}, data, false)
 
 	return err
 }
 
 // ReadToken reads arbitrary token from the luks metadata.
 func (l *LUKS) ReadToken(ctx context.Context, devname string, slot int, token token.Token) error {
-	stdout, err := l.runCommand(ctx, []string{"token", "export", "-q", devname, "--token-id", strconv.Itoa(slot), "--json-file=-"}, nil)
+	stdout, err := l.runCommand(ctx, []string{"token", "export", "-q", devname, "--token-id", strconv.Itoa(slot), "--json-file=-"}, nil, true)
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func (l *LUKS) ReadToken(ctx context.Context, devname string, slot int, token to
 
 // RemoveToken removes token from the luks metadata.
 func (l *LUKS) RemoveToken(ctx context.Context, devname string, slot int) error {
-	_, err := l.runCommand(ctx, []string{"token", "remove", "--token-id", strconv.Itoa(slot), devname}, nil)
+	_, err := l.runCommand(ctx, []string{"token", "remove", "--token-id", strconv.Itoa(slot), devname}, nil, false)
 
 	return err
 }
@@ -362,10 +362,23 @@ func (l *LUKS) RemoveToken(ctx context.Context, devname string, slot int) error 
 var notFoundMatcher = regexp.MustCompile("(is not in use|Failed to get token)")
 
 // runCommand executes cryptsetup with arguments.
-func (l *LUKS) runCommand(ctx context.Context, args []string, stdin []byte) (string, error) {
-	stdout, err := cmd.RunContext(cmd.WithStdin(
+func (l *LUKS) runCommand(ctx context.Context, args []string, stdin []byte, captureStdout bool) (string, error) {
+	var opts []cmd.Option
+
+	if captureStdout {
+		opts = append(opts, cmd.WithFullStdoutCapture())
+	}
+
+	if stdin != nil {
+		opts = append(opts, cmd.WithStandardInput(bytes.NewReader(stdin)))
+	}
+
+	stdout, err := cmd.RunWithOptions(
 		ctx,
-		bytes.NewReader(stdin)), "cryptsetup", args...)
+		"cryptsetup",
+		args,
+		opts...,
+	)
 	if err != nil {
 		var exitError *cmd.ExitError
 		if errors.As(err, &exitError) {

--- a/encryption/luks/luks_test.go
+++ b/encryption/luks/luks_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,7 +153,7 @@ func TestLUKSEncrypt(t *testing.T) {
 
 	token := &luks.Token[SealedKey]{
 		UserData: SealedKey{
-			SealedKey: "aaaa",
+			SealedKey: strings.Repeat("aaaa", 1024), // 4KB
 		},
 		Type: "sealedkey",
 	}
@@ -163,7 +164,7 @@ func TestLUKSEncrypt(t *testing.T) {
 	err = provider.ReadToken(ctx, path, 0, token)
 	require.NoError(t, err)
 
-	require.Equal(t, token.UserData.SealedKey, "aaaa")
+	require.Equal(t, token.UserData.SealedKey, token.UserData.SealedKey)
 
 	require.NoError(t, provider.RemoveToken(ctx, path, 0))
 	require.Error(t, provider.ReadToken(ctx, path, 0, token))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.3
 	github.com/siderolabs/gen v0.8.5
-	github.com/siderolabs/go-cmd v0.1.3
+	github.com/siderolabs/go-cmd v0.2.0
 	github.com/siderolabs/go-pointer v1.0.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
 github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
-github.com/siderolabs/go-cmd v0.1.3 h1:JrgZwqhJQeoec3QRON0LK+fv+0y7d0DyY7zsfkO6ciw=
-github.com/siderolabs/go-cmd v0.1.3/go.mod h1:bg7HY4mRNu4zKebAgUevSwuYNtcvPMJfuhLRkVKHZ0k=
+github.com/siderolabs/go-cmd v0.2.0 h1:fZ0jbQzZg4bFLmJzNEDZM/RlebZsfHOo2k+PCJ6g7y4=
+github.com/siderolabs/go-cmd v0.2.0/go.mod h1:YA/UEDh8Av84RlI4LfQw7HN9+vgxUrQw/Byef1dgptY=
 github.com/siderolabs/go-pointer v1.0.1 h1:f7Yi4IK1jptS8yrT9GEbwhmGcVxvPQgBUG/weH3V3DM=
 github.com/siderolabs/go-pointer v1.0.1/go.mod h1:C8Q/3pNHT4RE9e4rYR9PHeS6KPMlStRBgYrJQJNy/vA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
Update go-cmd, modernize API.

Ensure that `ReadToken` captures full stdout.

Fixes #146