### PR TITLE
fix: stale read issue when probing

### DIFF
--- a/blkid/probe_linux.go
+++ b/blkid/probe_linux.go
@@ -36,6 +36,11 @@ func Probe(f *os.File, opts ...ProbeOption) (*Info, error) {
 
 	switch sysStat.Mode & unix.S_IFMT {
 	case unix.S_IFBLK:
+		// Invalidate page cache before reading to ensure fresh data from the device.
+		// This is critical when a process (e.g., cryptsetup) wrote to the device using O_DIRECT,
+		// which can leave the block device's page cache stale (especially with loop devices).
+		unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED) //nolint:errcheck
+
 		// block device, initialize full support
 		info.BlockDevice = block.NewFromFile(f)
 


### PR DESCRIPTION
An utility used to format the partition (e.g. cryptsetup) might open the block device with `O_DIRECT`, so the next read done by the probing code might be hitting the buffer cache, and it doesn't see the writes done by `cryptsetup` (the cache is not coherent).

We can't use `O_DIRECT` for I/O, as it has tight requirements for aligning the reads and writes, so instead ask Linux to invalidate the cache before probing.

We only probe on blockdevice changes, so it shouldn't cause performance issues.