### PR TITLE
feat: validate luks header

### DIFF
--- a/blkid/internal/filesystems/luks/luks.go
+++ b/blkid/internal/filesystems/luks/luks.go
@@ -20,7 +20,7 @@ import (
 
 var luksMagic = magic.Magic{
 	Offset: 0,
-	Value:  []byte("LUKS\xba\xbe"),
+	Value:  []byte(luks2.MagicValue),
 }
 
 // Probe for the filesystem.

--- a/encryption/luks/header.go
+++ b/encryption/luks/header.go
@@ -1,0 +1,184 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package luks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/siderolabs/go-blockdevice/v2/block"
+	"github.com/siderolabs/go-blockdevice/v2/encryption"
+	"github.com/siderolabs/go-blockdevice/v2/internal/luks2"
+)
+
+type luksHeader struct {
+	jsonMetadata *encryption.JSONMetadata
+	header       luks2.Luks2Header
+	raw          []byte
+}
+
+// Read both LUKS headers.
+func (l *LUKS) readHeader(deviceName string) (*luksHeader, error) {
+	bd, err := block.NewFromPath(deviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer bd.Close() //nolint:errcheck
+
+	sb1 := make(luks2.Luks2Header, 4096)
+
+	if _, err = io.ReadFull(bd.File(), sb1[:]); err != nil {
+		return nil, err
+	}
+
+	if string(sb1.Get_magic()) != luks2.MagicValue {
+		return nil, fmt.Errorf("invalid LUKS2 header magic (is %q a LUKS device?): %s", deviceName, string(sb1.Get_magic()))
+	}
+
+	jsonAreaRaw1 := make([]byte, sb1.Get_hdr_size()-uint64(len(sb1)))
+	if _, err = io.ReadFull(bd.File(), jsonAreaRaw1); err != nil {
+		return nil, err
+	}
+
+	jsonArea1 := bytes.Trim(bytes.TrimSpace(jsonAreaRaw1), "\x00")
+
+	sb2 := make(luks2.Luks2Header, 4096)
+
+	if _, err = io.ReadFull(bd.File(), sb2[:]); err != nil {
+		return nil, err
+	}
+
+	jsonAreaRaw2 := make([]byte, int(sb1.Get_hdr_size())-len(sb1))
+	if _, err = io.ReadFull(bd.File(), jsonAreaRaw2); err != nil {
+		return nil, err
+	}
+
+	jsonArea2 := bytes.Trim(bytes.TrimSpace(jsonAreaRaw2), "\x00")
+
+	// a tmp struct to unmarshal only the offset in case rest of the json is corrupted
+	type segment struct {
+		Offset string `json:"offset"`
+	}
+
+	type jsonOffsetMeta struct {
+		Segments map[string]segment `json:"segments"`
+	}
+
+	var offsetMeta jsonOffsetMeta
+
+	if err = json.Unmarshal(jsonArea1, &offsetMeta); err != nil {
+		if err = json.Unmarshal(jsonArea2, &offsetMeta); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON area of both headers: %w", err)
+		}
+	}
+
+	dataOffset, err := strconv.Atoi(offsetMeta.Segments["0"].Offset)
+	if err != nil {
+		return nil, fmt.Errorf("invalid data offset: %w", err)
+	}
+
+	if dataOffset == 0 {
+		return nil, fmt.Errorf("unexpected zero data offset")
+	}
+
+	headerData := make([]byte, dataOffset)
+
+	if _, err = bd.File().Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	if _, err = io.ReadFull(bd.File(), headerData); err != nil {
+		return nil, err
+	}
+
+	// validate that the headers are identical if they have the same seqid
+	if sb1.Get_seqid() == sb2.Get_seqid() {
+		if !bytes.Equal(jsonArea1, jsonArea2) {
+			return nil, fmt.Errorf("LUKS2 headers have the same seqid but different JSON areas")
+		}
+	}
+
+	// pick the header with the higher seqid
+	selectedHeader := sb1
+	selectedJSON := jsonArea1
+
+	if sb1.Get_seqid() < sb2.Get_seqid() {
+		selectedHeader = sb2
+		selectedJSON = jsonArea2
+	}
+
+	var metadata *encryption.JSONMetadata
+
+	if err = json.Unmarshal(selectedJSON, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON area: %w", err)
+	}
+
+	if err := validateHeader(selectedHeader, metadata); err != nil {
+		return nil, fmt.Errorf("LUKS2 header validation error: %w", err)
+	}
+
+	return &luksHeader{
+		jsonMetadata: metadata,
+		header:       selectedHeader,
+		raw:          headerData,
+	}, nil
+}
+
+var validCiphers = map[string]struct{}{
+	AESXTSPlain64CipherString: {},
+	XChaCha12String:           {},
+	XChaCha20String:           {},
+}
+
+func validateHeader(sb luks2.Luks2Header, metadata *encryption.JSONMetadata) error {
+	if sb.Get_version() != 2 {
+		return fmt.Errorf("unexpected LUKS2 primary header version: %d", sb.Get_version())
+	}
+
+	if len(metadata.Keyslots) == 0 {
+		return fmt.Errorf("no keyslots found")
+	}
+
+	for id, keyslot := range metadata.Keyslots {
+		if keyslot.Type != "luks2" {
+			return fmt.Errorf("keyslot %s has unexpected type %q", id, keyslot.Type)
+		}
+
+		if _, ok := validCiphers[keyslot.Area.Encryption]; !ok {
+			return fmt.Errorf("keyslot %s has unexpected area encryption %q", id, keyslot.Area.Encryption)
+		}
+
+		if keyslot.KDF.Type != "argon2id" {
+			return fmt.Errorf("keyslot %s has unexpected KDF type %q", id, keyslot.KDF.Type)
+		}
+	}
+
+	if len(metadata.Segments) != 1 {
+		return fmt.Errorf("expected 1 segment, got %d", len(metadata.Segments))
+	}
+
+	segment, ok := metadata.Segments["0"]
+	if !ok {
+		return fmt.Errorf("segment 0 not found")
+	}
+
+	if segment.Type != "crypt" {
+		return fmt.Errorf("segment 0 has unexpected type %q", segment.Type)
+	}
+
+	if _, ok := validCiphers[segment.Encryption]; !ok {
+		return fmt.Errorf("segment 0 has unexpected encryption %q", segment.Encryption)
+	}
+
+	if len(segment.Flags) > 0 {
+		return fmt.Errorf("segment 0 has unexpected flags: %v", segment.Flags)
+	}
+
+	return nil
+}

--- a/encryption/luks/header_test.go
+++ b/encryption/luks/header_test.go
@@ -1,0 +1,183 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:testpackage
+package luks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/go-blockdevice/v2/encryption"
+	"github.com/siderolabs/go-blockdevice/v2/internal/luks2"
+)
+
+func newTestHeader(seqid uint64, version uint16) luks2.Luks2Header {
+	h := make(luks2.Luks2Header, 4096)
+	h.Put_version(version)
+	h.Put_seqid(seqid)
+
+	return h
+}
+
+func defaultKeyslot() *encryption.Keyslot {
+	return &encryption.Keyslot{
+		Type: "luks2",
+		Area: encryption.KeyslotArea{Encryption: AESXTSPlain64CipherString},
+		KDF:  encryption.KeyslotKDF{Type: "argon2id"},
+	}
+}
+
+func defaultMetadata() *encryption.JSONMetadata {
+	return &encryption.JSONMetadata{
+		Keyslots: map[string]*encryption.Keyslot{"0": defaultKeyslot()},
+		Segments: map[string]*encryption.Segment{
+			"0": {Type: "crypt", Encryption: AESXTSPlain64CipherString},
+		},
+	}
+}
+
+func TestValidateHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		metadata    *encryption.JSONMetadata
+		name        string
+		wantContain string
+		version     uint16
+	}{
+		{
+			name:     "valid",
+			metadata: defaultMetadata(),
+		},
+		{
+			name: "valid with xchacha12",
+			metadata: &encryption.JSONMetadata{
+				Keyslots: map[string]*encryption.Keyslot{
+					"0": {
+						Type: "luks2",
+						Area: encryption.KeyslotArea{Encryption: XChaCha12String},
+						KDF:  encryption.KeyslotKDF{Type: "argon2id"},
+					},
+				},
+				Segments: map[string]*encryption.Segment{
+					"0": {Type: "crypt", Encryption: XChaCha12String},
+				},
+			},
+		},
+		{
+			name:        "invalid header version",
+			version:     1,
+			metadata:    defaultMetadata(),
+			wantContain: "header version",
+		},
+		{
+			name: "invalid keyslot type",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				ks := defaultKeyslot()
+				ks.Type = "luks1"
+				m.Keyslots["0"] = ks
+
+				return m
+			}(),
+			wantContain: "unexpected type",
+		},
+		{
+			name: "invalid keyslot area encryption",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				ks := defaultKeyslot()
+				ks.Area.Encryption = "serpent-xts-plain64"
+				m.Keyslots["0"] = ks
+
+				return m
+			}(),
+			wantContain: "unexpected area encryption",
+		},
+		{
+			name: "invalid KDF type",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				ks := defaultKeyslot()
+				ks.KDF.Type = "pbkdf2"
+				m.Keyslots["0"] = ks
+
+				return m
+			}(),
+			wantContain: "unexpected KDF type",
+		},
+		{
+			name: "no keyslots",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				m.Keyslots = map[string]*encryption.Keyslot{}
+
+				return m
+			}(),
+			wantContain: "no keyslots found",
+		},
+		{
+			name: "multiple segments",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				m.Segments["1"] = &encryption.Segment{Type: "crypt", Encryption: AESXTSPlain64CipherString}
+
+				return m
+			}(),
+			wantContain: "expected 1 segment",
+		},
+		{
+			name: "invalid segment type",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				m.Segments["0"] = &encryption.Segment{Type: "linear", Encryption: AESXTSPlain64CipherString}
+
+				return m
+			}(),
+			wantContain: "unexpected type",
+		},
+		{
+			name: "invalid segment encryption",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				m.Segments["0"] = &encryption.Segment{Type: "crypt", Encryption: "null"}
+
+				return m
+			}(),
+			wantContain: "unexpected encryption",
+		},
+		{
+			name: "segment with flags",
+			metadata: func() *encryption.JSONMetadata {
+				m := defaultMetadata()
+				m.Segments["0"] = &encryption.Segment{Type: "crypt", Encryption: AESXTSPlain64CipherString, Flags: []string{"allow-discards"}}
+
+				return m
+			}(),
+			wantContain: "unexpected flags",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			version := tt.version
+			if version == 0 {
+				version = 2
+			}
+
+			err := validateHeader(
+				newTestHeader(1, version),
+				tt.metadata,
+			)
+
+			if tt.wantContain == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantContain)
+			}
+		})
+	}
+}

--- a/encryption/luks/luks.go
+++ b/encryption/luks/luks.go
@@ -8,10 +8,9 @@ package luks
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -21,10 +20,8 @@ import (
 
 	"github.com/siderolabs/go-cmd/pkg/cmd"
 
-	"github.com/siderolabs/go-blockdevice/v2/block"
 	"github.com/siderolabs/go-blockdevice/v2/encryption"
 	"github.com/siderolabs/go-blockdevice/v2/encryption/token"
-	"github.com/siderolabs/go-blockdevice/v2/internal/luks2"
 )
 
 // Cipher LUKS2 cipher type.
@@ -137,11 +134,31 @@ func New(cipher Cipher, options ...Option) *LUKS {
 
 // Open runs luksOpen on a device and returns mapped device path.
 func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *encryption.Key) (string, error) {
+	header, err := l.readHeader(deviceName)
+	if err != nil {
+		return "", err
+	}
+
+	// Write the detached header strictly to RAM
+	file, err := os.CreateTemp("", "luks-header-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create detached LUKS header file: %w", err)
+	}
+
+	_, err = file.Write(header.raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to write detached LUKS header: %w", err)
+	}
+
+	defer os.Remove(file.Name()) //nolint:errcheck
+	defer file.Close()           //nolint:errcheck
+
 	args := slices.Concat(
 		[]string{
 			"luksOpen",
 			deviceName,
 			mappedName,
+			fmt.Sprintf("--header=%s", file.Name()),
 			"--key-file=-",
 			fmt.Sprintf("--keyfile-size=%d", len(key.Value)),
 		},
@@ -149,7 +166,7 @@ func (l *LUKS) Open(ctx context.Context, deviceName, mappedName string, key *enc
 		l.perfArgs(),
 	)
 
-	_, err := l.runCommand(ctx, args, key.Value, false)
+	_, err = l.runCommand(ctx, args, key.Value, false)
 	if err != nil {
 		return "", err
 	}
@@ -297,34 +314,12 @@ func (l *LUKS) RemoveKey(ctx context.Context, devname string, slot int, key *enc
 
 // ReadKeyslots returns deserialized LUKS2 keyslots JSON.
 func (l *LUKS) ReadKeyslots(deviceName string) (*encryption.Keyslots, error) {
-	bd, err := block.NewFromPath(deviceName)
+	header, err := l.readHeader(deviceName)
 	if err != nil {
 		return nil, err
 	}
 
-	defer bd.Close() //nolint:errcheck
-
-	sb := make(luks2.Luks2Header, 4096)
-
-	if _, err = io.ReadFull(bd.File(), sb[:]); err != nil {
-		return nil, err
-	}
-
-	jsonArea := make([]byte, int(sb.Get_hdr_size())-len(sb))
-
-	if _, err = io.ReadFull(bd.File(), jsonArea); err != nil {
-		return nil, err
-	}
-
-	jsonArea = bytes.Trim(bytes.TrimSpace(jsonArea), "\x00")
-
-	var keyslots *encryption.Keyslots
-
-	if err = json.Unmarshal(jsonArea, &keyslots); err != nil {
-		return nil, err
-	}
-
-	return keyslots, nil
+	return &encryption.Keyslots{Keyslots: header.jsonMetadata.Keyslots}, nil
 }
 
 // SetToken adds arbitrary token to the key slot.

--- a/encryption/luks/luks_test.go
+++ b/encryption/luks/luks_test.go
@@ -5,8 +5,10 @@
 package luks_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"io"
 	randv2 "math/rand/v2"
@@ -222,6 +224,35 @@ func TestLUKSEncrypt(t *testing.T) {
 
 	_, err = provider.Open(ctx, loDev.Path(), mappedName, key)
 	require.Error(t, err)
+
+	// tamper the on-disk header: corrupt KDF type in both JSON areas
+	func() {
+		f, err1 := os.OpenFile(path, os.O_RDWR, 0)
+		require.NoError(t, err1)
+
+		defer f.Close() //nolint:errcheck
+
+		// read hdr_size from binary header (big-endian uint64 at offset 8)
+		binHdr := make([]byte, 16)
+		_, err = io.ReadFull(f, binHdr)
+		require.NoError(t, err)
+
+		hdrSize := binary.BigEndian.Uint64(binHdr[8:16])
+
+		// tamper both JSON areas: "argon2xx" is the same length as "argon2id"
+		for _, offset := range []int64{4096, int64(hdrSize) + 4096} {
+			buf := make([]byte, 8192)
+			_, err = f.ReadAt(buf, offset)
+			require.NoError(t, err)
+
+			tampered := bytes.ReplaceAll(buf, []byte(`"argon2id"`), []byte(`"argon2xx"`))
+			_, err = f.WriteAt(tampered, offset)
+			require.NoError(t, err)
+		}
+	}()
+
+	_, err = provider.Open(ctx, path, mappedName, key)
+	require.ErrorContains(t, err, "unexpected KDF type")
 }
 
 func TestLUKSKeyRotation(t *testing.T) {

--- a/encryption/provider.go
+++ b/encryption/provider.go
@@ -7,6 +7,8 @@ package encryption
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/siderolabs/go-blockdevice/v2/encryption/token"
 )
@@ -57,10 +59,56 @@ type Keyslots struct {
 	Keyslots map[string]*Keyslot `json:"keyslots"`
 }
 
+// JSONMetadata represents LUKS2 JSON metadata.
+type JSONMetadata struct {
+	Keyslots map[string]*Keyslot `json:"keyslots"`
+	Segments map[string]*Segment `json:"segments"`
+}
+
+// Segment represents a single LUKS2 segment.
+type Segment struct {
+	Type       string     `json:"type"`
+	Size       string     `json:"size"`
+	IVTweak    string     `json:"iv_tweak"`
+	Encryption string     `json:"encryption"`
+	Flags      []string   `json:"flags,omitempty"`
+	Offset     StringUint `json:"offset"`
+	SectorSize int64      `json:"sector_size"`
+}
+
+// StringUint is a uint64 that unmarshals from a JSON quoted string (e.g. "16777216").
+type StringUint uint64
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *StringUint) UnmarshalJSON(data []byte) error {
+	str := strings.Trim(string(data), "\"")
+
+	v, err := strconv.ParseUint(str, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*s = StringUint(v)
+
+	return nil
+}
+
+// KeyslotArea represents the area parameters of a LUKS2 keyslot.
+type KeyslotArea struct {
+	Encryption string `json:"encryption"`
+}
+
+// KeyslotKDF represents the KDF parameters of a LUKS2 keyslot.
+type KeyslotKDF struct {
+	Type string `json:"type"`
+}
+
 // Keyslot represents a single LUKS2 keyslot.
 type Keyslot struct {
-	Type    string `json:"type"`
-	KeySize int64  `json:"key_size"`
+	Type    string      `json:"type"`
+	Area    KeyslotArea `json:"area"`
+	KDF     KeyslotKDF  `json:"kdf"`
+	KeySize int64       `json:"key_size"`
 }
 
 // NewKey create a new key.

--- a/internal/luks2/luks2.go
+++ b/internal/luks2/luks2.go
@@ -5,4 +5,6 @@
 // Package luks2 contains LUKS header.
 package luks2
 
+const MagicValue = "LUKS\xba\xbe"
+
 //go:generate go run ../cstruct/cstruct.go -pkg luks2 -struct Luks2Header -input luks2_header.h -endianness BigEndian


### PR DESCRIPTION
Read the header, validate it, and only proceed to unlock with detached header once it is confirmed that it hasn't been tampered with.

closes https://github.com/siderolabs/talos/issues/12105