### PR TITLE
feat: add support for custom sector size for disk image GPT

### DIFF
--- a/partitioning/gpt/file.go
+++ b/partitioning/gpt/file.go
@@ -9,27 +9,57 @@ import (
 	"os"
 )
 
+// FileOptions is a set of options for DeviceFromFile.
+type FileOptions struct {
+	SectorSize uint
+}
+
+// FileOption is a function that sets some option for DeviceFromFile.
+type FileOption func(*FileOptions)
+
+// WithFileSectorSize sets the sector size to be reported by the file-based device.
+// Default is 512 bytes; pass 4096 (or another power of two) to work with disk
+// images authored for a different sector size.
+func WithFileSectorSize(size uint) FileOption {
+	return func(o *FileOptions) {
+		o.SectorSize = size
+	}
+}
+
 type fileWrapper struct {
-	f    *os.File
-	size uint64
+	f          *os.File
+	size       uint64
+	sectorSize uint
 }
 
 // DeviceFromFile creates a new Device from an os.File for use with disk image files.
 // This is useful for creating partition tables on file-based disk images without
 // requiring an actual block device.
 //
+// By default, the sector size is 512 bytes; use [WithFileSectorSize] to override
+// it (e.g. for 4K-sector disk images).
+//
 // Note: The file size is captured at the time of device creation. If the file is
 // truncated or resized after creating the Device, create a new Device to reflect
 // the updated size.
-func DeviceFromFile(f *os.File) (Device, error) {
+func DeviceFromFile(f *os.File, opts ...FileOption) (Device, error) {
+	options := FileOptions{
+		SectorSize: 512,
+	}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	info, err := f.Stat()
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat file: %w", err)
 	}
 
 	return &fileWrapper{
-		f:    f,
-		size: uint64(info.Size()),
+		f:          f,
+		size:       uint64(info.Size()),
+		sectorSize: options.SectorSize,
 	}, nil
 }
 
@@ -45,7 +75,7 @@ func (d *fileWrapper) WriteAt(p []byte, off int64) (int, error) {
 
 // GetSectorSize implements Device interface.
 func (d *fileWrapper) GetSectorSize() uint {
-	return 512 // Common default sector size for files
+	return d.sectorSize
 }
 
 // GetSize implements Device interface.
@@ -55,7 +85,7 @@ func (d *fileWrapper) GetSize() uint64 {
 
 // GetIOSize implements Device interface.
 func (d *fileWrapper) GetIOSize() (uint, error) {
-	return 512, nil
+	return d.sectorSize, nil
 }
 
 // Sync implements Device interface.

--- a/partitioning/gpt/file_test.go
+++ b/partitioning/gpt/file_test.go
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package gpt_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/go-blockdevice/v2/partitioning/gpt"
+)
+
+// gptSignature is the on-disk "EFI PART" magic at the start of a GPT header.
+var gptSignature = []byte("EFI PART")
+
+func newImageFile(t *testing.T, size int64) *os.File {
+	t.Helper()
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "image.raw"))
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(size))
+
+	t.Cleanup(func() {
+		assert.NoError(t, f.Close())
+	})
+
+	return f
+}
+
+func TestDeviceFromFileDefaultSectorSize(t *testing.T) {
+	f := newImageFile(t, 16*1024*1024)
+
+	dev, err := gpt.DeviceFromFile(f)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint(512), dev.GetSectorSize())
+
+	ioSize, err := dev.GetIOSize()
+	require.NoError(t, err)
+	assert.Equal(t, uint(512), ioSize)
+}
+
+func TestDeviceFromFileWithSectorSize(t *testing.T) {
+	for _, sectorSize := range []uint{512, 4096} {
+		t.Run("sector="+strconv.FormatUint(uint64(sectorSize), 10), func(t *testing.T) {
+			f := newImageFile(t, 64*1024*1024)
+
+			dev, err := gpt.DeviceFromFile(f, gpt.WithFileSectorSize(sectorSize))
+			require.NoError(t, err)
+
+			assert.Equal(t, sectorSize, dev.GetSectorSize())
+
+			ioSize, err := dev.GetIOSize()
+			require.NoError(t, err)
+			assert.Equal(t, sectorSize, ioSize)
+		})
+	}
+}
+
+// TestDeviceFromFileSectorSizeRoundTrip ensures the configured sector size is
+// honored end-to-end: a GPT table written through the file device with a 4K
+// sector size must place the primary header at LBA 1 of a 4K sector (offset
+// 4096), and a re-read must recover the same partition layout.
+func TestDeviceFromFileSectorSizeRoundTrip(t *testing.T) {
+	const (
+		MiB        = 1024 * 1024
+		imageSize  = 64 * MiB
+		sectorSize = 4096
+	)
+
+	partType := uuid.MustParse("0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+
+	f := newImageFile(t, imageSize)
+
+	dev, err := gpt.DeviceFromFile(f, gpt.WithFileSectorSize(sectorSize))
+	require.NoError(t, err)
+
+	table, err := gpt.New(dev)
+	require.NoError(t, err)
+
+	idx, _, err := table.AllocatePartition(8*MiB, "test", partType)
+	require.NoError(t, err)
+	require.Equal(t, 1, idx)
+
+	require.NoError(t, table.Write())
+
+	// Primary header sits at LBA 1, which with a 4K sector is offset 4096.
+	hdr := make([]byte, len(gptSignature))
+	_, err = f.ReadAt(hdr, sectorSize)
+	require.NoError(t, err)
+	assert.Equal(t, gptSignature, hdr, "expected GPT signature at offset %d (LBA 1 of %d-byte sectors)", sectorSize, sectorSize)
+
+	// At offset 512 (LBA 1 if sector size were 512) there must NOT be a GPT
+	// signature - that location is inside the protective MBR sector.
+	at512 := make([]byte, len(gptSignature))
+	_, err = f.ReadAt(at512, 512)
+	require.NoError(t, err)
+	assert.NotEqual(t, gptSignature, at512, "GPT signature unexpectedly found at offset 512; sector size override was not honored")
+
+	// Re-read the table and confirm partitions round-trip.
+	dev2, err := gpt.DeviceFromFile(f, gpt.WithFileSectorSize(sectorSize))
+	require.NoError(t, err)
+
+	table2, err := gpt.Read(dev2)
+	require.NoError(t, err)
+
+	assert.Equal(t, table.Partitions(), table2.Partitions())
+}
+
+// TestDeviceFromFileDefaultSectorPlacement is the 512-byte counterpart of the
+// test above - it pins the documented default behavior, so any future change
+// that silently shifts the default sector size will break here.
+func TestDeviceFromFileDefaultSectorPlacement(t *testing.T) {
+	const (
+		MiB       = 1024 * 1024
+		imageSize = 16 * MiB
+	)
+
+	partType := uuid.MustParse("0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+
+	f := newImageFile(t, imageSize)
+
+	dev, err := gpt.DeviceFromFile(f)
+	require.NoError(t, err)
+
+	table, err := gpt.New(dev)
+	require.NoError(t, err)
+
+	_, _, err = table.AllocatePartition(2*MiB, "test", partType)
+	require.NoError(t, err)
+
+	require.NoError(t, table.Write())
+
+	hdr := make([]byte, len(gptSignature))
+	_, err = f.ReadAt(hdr, 512)
+	require.NoError(t, err)
+	assert.Equal(t, gptSignature, hdr, "expected GPT signature at offset 512 with default 512-byte sectors")
+}


### PR DESCRIPTION
Allow to set sector size when creating GPT disk images.

Part of https://github.com/siderolabs/talos/issues/13227