### PR TITLE
fix: populate Modalias for NVMe disks

### DIFF
--- a/block/device.go
+++ b/block/device.go
@@ -49,7 +49,8 @@ type DeviceProperties struct {
 	Vendor string
 	// Serial /sys/block/<dev>/device/serial.
 	Serial string
-	// Modalias /sys/block/<dev>/device/modalias.
+	// Modalias from /sys/block/<dev>/device/modalias, falling back to
+	// /sys/block/<dev>/device/device/modalias when the former is absent (common on NVMe).
 	Modalias string
 	// WWID /sys/block/<dev>/wwid.
 	WWID string

--- a/block/device_linux.go
+++ b/block/device_linux.go
@@ -343,7 +343,7 @@ func (d *Device) GetProperties() (*DeviceProperties, error) {
 		Model:    readSysFsFile(filepath.Join(sysFsPath, "device", "model")),
 		Vendor:   readSysFsFile(filepath.Join(sysFsPath, "device", "vendor")),
 		Serial:   readSysFsFile(filepath.Join(sysFsPath, "serial")),
-		Modalias: readSysFsFile(filepath.Join(sysFsPath, "device", "modalias")),
+		Modalias: readBlockDeviceModalias(sysFsPath),
 		WWID:     readSysFsFile(filepath.Join(sysFsPath, "wwid")),
 		UUID:     readSysFsFile(filepath.Join(sysFsPath, "uuid")),
 	}
@@ -383,6 +383,16 @@ func (d *Device) GetProperties() (*DeviceProperties, error) {
 
 func readNVMeFirmwareRevision(sysFsPath string) string {
 	return readSysFsFile(filepath.Join(sysFsPath, "device", "firmware_rev"))
+}
+
+// readBlockDeviceModalias returns the modalias of the block device, falling
+// back to the underlying PCI device's modalias when /device/modalias is absent.
+func readBlockDeviceModalias(sysFsPath string) string {
+	if m := readSysFsFile(filepath.Join(sysFsPath, "device", "modalias")); m != "" {
+		return m
+	}
+
+	return readSysFsFile(filepath.Join(sysFsPath, "device", "device", "modalias"))
 }
 
 func (d *Device) getTransport(sysFsPath, deviceName string) string {

--- a/block/device_linux_internal_test.go
+++ b/block/device_linux_internal_test.go
@@ -32,3 +32,48 @@ func TestReadNVMeFirmwareRevision(t *testing.T) {
 		assert.Empty(t, readNVMeFirmwareRevision(t.TempDir()))
 	})
 }
+
+func TestReadBlockDeviceModalias(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scsi-style present at device/modalias", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "device"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "device", "modalias"), []byte("scsi:t-0x00\n"), 0o644))
+
+		assert.Equal(t, "scsi:t-0x00", readBlockDeviceModalias(root))
+	})
+
+	t.Run("nvme-style present only at device/device/modalias", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "device", "device"), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(root, "device", "device", "modalias"),
+			[]byte("pci:v000015B7d00005030sv000015B7sd00005030bc01sc08i02\n"),
+			0o644,
+		))
+
+		assert.Equal(t, "pci:v000015B7d00005030sv000015B7sd00005030bc01sc08i02", readBlockDeviceModalias(root))
+	})
+
+	t.Run("device/modalias takes precedence", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "device", "device"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "device", "modalias"), []byte("primary\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "device", "device", "modalias"), []byte("fallback\n"), 0o644))
+
+		assert.Equal(t, "primary", readBlockDeviceModalias(root))
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Empty(t, readBlockDeviceModalias(t.TempDir()))
+	})
+}


### PR DESCRIPTION
DeviceProperties.Modalias was empty for NVMe namespaces because the kernel exposes the PCI device at a different path than SCSI/ATA.