### PR TITLE
feat: expose Vendor on DeviceProperties

### DIFF
--- a/blkid/blkid_linux_test.go
+++ b/blkid/blkid_linux_test.go
@@ -97,7 +97,7 @@ func vfatSetup(bits int) func(t *testing.T, path string) {
 	return func(t *testing.T, path string) {
 		t.Helper()
 
-		cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-F", strconv.Itoa(bits), "-n", "TALOS_V1", "-v", path)
+		cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-I", "-F", strconv.Itoa(bits), "-n", "TALOS_V1", "-v", path)
 		cmd.Stdout = t.Output()
 		cmd.Stderr = t.Output()
 

--- a/block/device.go
+++ b/block/device.go
@@ -45,6 +45,8 @@ type DeviceProperties struct {
 	DeviceName string
 	// Model from /sys/block/*/device/model.
 	Model string
+	// Vendor from /sys/block/<dev>/device/vendor.
+	Vendor string
 	// Serial /sys/block/<dev>/device/serial.
 	Serial string
 	// Modalias /sys/block/<dev>/device/modalias.

--- a/block/device_linux.go
+++ b/block/device_linux.go
@@ -341,6 +341,7 @@ func (d *Device) GetProperties() (*DeviceProperties, error) {
 
 	props := &DeviceProperties{
 		Model:    readSysFsFile(filepath.Join(sysFsPath, "device", "model")),
+		Vendor:   readSysFsFile(filepath.Join(sysFsPath, "device", "vendor")),
 		Serial:   readSysFsFile(filepath.Join(sysFsPath, "serial")),
 		Modalias: readSysFsFile(filepath.Join(sysFsPath, "device", "modalias")),
 		WWID:     readSysFsFile(filepath.Join(sysFsPath, "wwid")),

--- a/encryption/luks/luks_test.go
+++ b/encryption/luks/luks_test.go
@@ -146,7 +146,7 @@ func TestLUKSEncrypt(t *testing.T) {
 
 	mountPath := t.TempDir()
 
-	cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-F", "32", "-n", "config", encryptedPath)
+	cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-I", "-F", "32", "-n", "config", encryptedPath)
 	require.NoError(t, cmd.Run())
 
 	type SealedKey struct {

--- a/partitioning/gpt/gpt_test.go
+++ b/partitioning/gpt/gpt_test.go
@@ -791,7 +791,7 @@ func createVFATImage(t *testing.T) string {
 
 	// Format as VFAT with reproducible output
 	// Use FAT32 with 4096 byte sectors to match systemd-repart defaults
-	cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-F", "32", "-S", "4096", "-n", "TESTIMAGE", "--invariant", imgPath)
+	cmd := exec.CommandContext(t.Context(), "mkfs.vfat", "-I", "-F", "32", "-S", "4096", "-n", "TESTIMAGE", "--invariant", imgPath)
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "mkfs.vfat failed: %s", output)
 


### PR DESCRIPTION
Read /sys/block/<dev>/device/vendor and surface it as DeviceProperties.Vendor. Populated for SCSI/SAS disks (real SCSI subsystem) and reported as "ATA" for SATA disks (libata convention). Empty for NVMe, which does not expose a vendor string at this path